### PR TITLE
Improve intrinsics support for CheriBSD.

### DIFF
--- a/clang/lib/Headers/cheri_init_globals_bw.h
+++ b/clang/lib/Headers/cheri_init_globals_bw.h
@@ -8,15 +8,13 @@
 // TODO - Remove once all references have been updated.
 #include <cheri_init_globals.h>
 
-#define ELF64_R_TYPE(INFO) ((INFO) & 0xFFFFFFFF)
-#define ELF32_R_TYPE(INFO) ((INFO) & 0xFF)
+// Add local definitions of the ELF structures to avoid dependencies.
 #if __CHERI_ADDRESS_BITS__ == 32
-#define R_TYPE ELF32_R_TYPE
+#define CIG_R_TYPE(INFO) ((INFO) & 0xFF)
 #else
-#define R_TYPE ELF64_R_TYPE
+#define CIG_R_TYPE(INFO) ((INFO) & 0xFFFFFFFF)
 #endif
-
-struct ELFRela {
+struct CIG_ELF_Rela {
   __SIZE_TYPE__ offset;
   __SIZE_TYPE__ info;
   __SIZE_TYPE__ addend;
@@ -27,13 +25,14 @@ struct ELFRela {
 #define R_RISCV_CHERI_RELATIVE 202
 #endif
 
-static __attribute__((always_inline)) void cheri_init_globals_cbuildcap_impl(
-    const struct ELFRela *start_rela, const struct ELFRela *stop_rela,
+static __attribute__((always_inline, unused)) void
+cheri_init_globals_cbuildcap_impl(
+    const struct CIG_ELF_Rela *start_rela, const struct CIG_ELF_Rela *stop_rela,
     void *__capability data_cap, const void *__capability code_cap,
     const void *__capability rodata_cap, bool tight_code_bounds,
     __SIZE_TYPE__ base_addr, bool init_with_cbld) {
-  for (const struct ELFRela *rela = start_rela; rela < stop_rela; rela++) {
-    if (R_TYPE(rela->info) != R_RISCV_CHERI_RELATIVE)
+  for (const struct CIG_ELF_Rela *rela = start_rela; rela < stop_rela; rela++) {
+    if (CIG_R_TYPE(rela->info) != R_RISCV_CHERI_RELATIVE)
       continue;
     const void *__capability *__capability dest =
         (const void *__capability *__capability)__builtin_cheri_address_set(
@@ -84,12 +83,12 @@ static __attribute__((always_inline)) void cheri_init_globals_cbuildcap_impl(
   }
 }
 
-static __attribute__((always_inline)) void
+static __attribute__((always_inline, unused)) void
 cheri_init_globals_cbuildcap(void *__capability data_cap,
                              const void *__capability code_cap,
                              const void *__capability rodata_cap) {
-  const struct ELFRela *start_relocs;
-  const struct ELFRela *stop_relocs;
+  const struct CIG_ELF_Rela *start_relocs;
+  const struct CIG_ELF_Rela *stop_relocs;
   __SIZE_TYPE__ start_addr, stop_addr;
 #if !defined(__CHERI_PURE_CAPABILITY__)
   __asm__(
@@ -118,8 +117,8 @@ cheri_init_globals_cbuildcap(void *__capability data_cap,
     return;
 
 #if !defined(__CHERI_PURE_CAPABILITY__)
-  start_relocs = (const struct ELFRela *)(__UINTPTR_TYPE__)start_addr;
-  stop_relocs = (const struct ELFRela *)(__UINTPTR_TYPE__)stop_addr;
+  start_relocs = (const struct CIG_ELF_Rela *)(__UINTPTR_TYPE__)start_addr;
+  stop_relocs = (const struct CIG_ELF_Rela *)(__UINTPTR_TYPE__)stop_addr;
 #else
   __SIZE_TYPE__ relocs_size = stop_addr - start_addr;
   /*
@@ -127,7 +126,7 @@ cheri_init_globals_cbuildcap(void *__capability data_cap,
    * rodata and rw data, too so we can access __cap_relocs, no matter where it
    * was placed.
    */
-  start_relocs = (const struct ELFRela *)__builtin_cheri_address_set(
+  start_relocs = (const struct CIG_ELF_Rela *)__builtin_cheri_address_set(
       __builtin_cheri_program_counter_get(), start_addr);
   start_relocs = __builtin_cheri_bounds_set(start_relocs, relocs_size);
   /*
@@ -136,8 +135,8 @@ cheri_init_globals_cbuildcap(void *__capability data_cap,
    * TODO: use csetboundsexact and teach the linker to align __cap_relocs.
    */
   stop_relocs =
-      (const struct ELFRela *)(const void *)((const char *)start_relocs +
-                                              relocs_size);
+      (const struct CIG_ELF_Rela *)(const void *)((const char *)start_relocs +
+                                                  relocs_size);
 #endif
 
 #if !defined(__CHERI_PURE_CAPABILITY__) || __CHERI_CAPABILITY_TABLE__ == 3

--- a/clang/lib/Headers/cheriintrin.h
+++ b/clang/lib/Headers/cheriintrin.h
@@ -25,9 +25,7 @@
 #define cheri_length_get(x) __builtin_cheri_length_get(x)
 #define cheri_offset_get(x) __builtin_cheri_offset_get(x)
 #define cheri_offset_set(x, y) __builtin_cheri_offset_set((x), (y))
-#if !defined(__riscv_zcheripurecap)
 #define cheri_tag_clear(x) __builtin_cheri_tag_clear(x)
-#endif
 #define cheri_tag_get(x) __builtin_cheri_tag_get(x)
 #define cheri_is_valid(x) __builtin_cheri_tag_get(x)
 #define cheri_is_invalid(x) (!__builtin_cheri_tag_get(x))

--- a/clang/lib/Headers/cheriintrin.h
+++ b/clang/lib/Headers/cheriintrin.h
@@ -42,12 +42,12 @@
 
 /* Object types, sealing and unsealing: */
 typedef long cheri_otype_t;
-#if defined(__mips__) || defined(__riscv)
+#if defined(__mips__) || defined(__riscv_xcheri)
 /* CHERI-MIPS and CHERI-RISC-V use negative numbers for hardware-interpreted
  * otypes */
 #define CHERI_OTYPE_UNSEALED ((cheri_otype_t)-1)
 #define CHERI_OTYPE_SENTRY ((cheri_otype_t)-2)
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(__riscv_zcheripurecap)
 #define CHERI_OTYPE_UNSEALED ((cheri_otype_t)0)
 #define CHERI_OTYPE_SENTRY ((cheri_otype_t)1)
 #else

--- a/clang/lib/Headers/cheriintrin.h
+++ b/clang/lib/Headers/cheriintrin.h
@@ -114,9 +114,11 @@ typedef enum __attribute__((flag_enum, enum_extensibility(open))) {
 
 /* Partially portable builtins: */
 /* Note: {get,set}flags does nothing for MIPS, but can still be used. */
-#if !defined(__riscv_zcheripurecap)
+#if defined(__riscv_zcherihybrid) || defined(__riscv_xcheri)
 #define cheri_flags_get(x) __builtin_cheri_flags_get(x)
 #define cheri_flags_set(x, y) __builtin_cheri_flags_set((x), (y))
+#endif
+#if !defined(__riscv_zcheripurecap)
 #define cheri_tags_load(x) __builtin_cheri_cap_load_tags(x)
 #endif
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -322,7 +322,6 @@ static bool VerifyBakewellBuiltins(Sema &S, unsigned BuiltinID, CallExpr *TheCal
   case Builtin::BI__builtin_cheri_cap_type_copy:
   case Builtin::BI__builtin_cheri_unseal:
   case Builtin::BI__builtin_cheri_conditional_seal:
-  case Builtin::BI__builtin_cheri_tag_clear:
   case Builtin::BI__builtin_cheri_seal:
   case Builtin::BI__builtin_cheri_cap_load_tags:
     S.Diag(TheCall->getBeginLoc(), diag::err_bakewell_unsupported_builtin)

--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -139,7 +139,6 @@ if( NOT CLANG_BUILT_STANDALONE )
     llvm-readtapi
     llvm-strip
     llvm-symbolizer
-    llvm-windres
     obj2yaml
     opt
     split-file

--- a/clang/test/Sema/cheri/bakewell/verify-builtins.c
+++ b/clang/test/Sema/cheri/bakewell/verify-builtins.c
@@ -9,7 +9,6 @@ void standard(void * __capability cap){
 
     x = __builtin_cheri_cap_load_tags(cap); // expected-error{{builtin unsupported when using bakewell : Unsupported Builtin}}
     void * __capability volatile z;
-    z = __builtin_cheri_tag_clear(cap); // expected-error{{builtin unsupported when using bakewell : Unsupported Builtin}}
     z = __builtin_cheri_unseal(cap, cap); // expected-error{{builtin unsupported when using bakewell : Unsupported Builtin}}
     z = __builtin_cheri_cap_type_copy(cap, cap); // expected-error{{builtin unsupported when using bakewell : Unsupported Builtin}}
     z = __builtin_cheri_seal(cap, cap); // expected-error{{builtin unsupported when using bakewell : Unsupported Builtin}}

--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -70,6 +70,9 @@ private:
                              MachineBasicBlock::iterator MBBI,
                              MachineBasicBlock::iterator &NextMBBI);
   bool expandCGetAddr(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
+  bool expandHybridPCCGet(MachineBasicBlock &MBB,
+                          MachineBasicBlock::iterator MBBI,
+                          MachineBasicBlock::iterator &NextMBBI);
   bool expandCCOp(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
                   MachineBasicBlock::iterator &NextMBBI);
   bool expandVSetVL(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
@@ -141,6 +144,8 @@ bool RISCVExpandPseudo::expandMI(MachineBasicBlock &MBB,
     return expandCapLoadTLSIEAddress(MBB, MBBI, NextMBBI);
   case RISCV::PseudoCLC_TLS_GD:
     return expandCapLoadTLSGDCap(MBB, MBBI, NextMBBI);
+  case RISCV::PseudoPCCGet:
+    return expandHybridPCCGet(MBB, MBBI, NextMBBI);
   case RISCV::PseudoRV32ZdinxSD:
     return expandRV32ZdinxStore(MBB, MBBI);
   case RISCV::PseudoRV32ZdinxLD:
@@ -307,6 +312,25 @@ bool RISCVExpandPseudo::expandCGetAddr(MachineBasicBlock &MBB,
       .addImm(0);
   MBBI->eraseFromParent(); // The pseudo instruction is gone now.
   return true;
+}
+
+bool RISCVExpandPseudo::expandHybridPCCGet(
+    MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
+    MachineBasicBlock::iterator &NextMBBI) {
+  const auto &STI = MBB.getParent()->getSubtarget<RISCVSubtarget>();
+
+  if (STI.hasStdExtZCheriHybrid() && !STI.isCapMode()) {
+    Register DstReg = MBBI->getOperand(0).getReg();
+    DebugLoc DL = MBBI->getDebugLoc();
+
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::MODESW_CAP));
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::AUIPC), DstReg).addImm(0);
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::MODESW_INT));
+    MBBI->eraseFromParent();
+    return true;
+  }
+
+  return false;
 }
 
 bool RISCVExpandPseudo::expandCCOp(MachineBasicBlock &MBB,

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -5671,6 +5671,26 @@ SDValue RISCVTargetLowering::lowerVPCttzElements(SDValue Op,
   return DAG.getNode(ISD::TRUNCATE, DL, Op.getValueType(), Res);
 }
 
+// On architectures without a dedicated CClearTag instruction, the tag is
+// cleared by writing to to the high bits of the capability.
+static SDValue emitCClearTagReplacement(SelectionDAG &DAG,
+                                        const RISCVSubtarget &Subtarget,
+                                        const SDLoc &DL, SDValue Cap,
+                                        EVT XLenVT) {
+  if (Subtarget.hasCheri()) {
+    // Use existing CClearTag selection
+    return SDValue();
+  }
+  SDValue CapHigh = DAG.getNode(
+      ISD::INTRINSIC_WO_CHAIN, DL, XLenVT,
+      DAG.getConstant(Intrinsic::cheri_cap_high_get, DL, XLenVT), Cap);
+  SDValue Result = DAG.getNode(
+      ISD::INTRINSIC_WO_CHAIN, DL, Cap.getValueType(),
+      DAG.getConstant(Intrinsic::cheri_cap_high_set, DL, XLenVT), Cap, CapHigh);
+
+  return Result;
+}
+
 // While RVV has alignment restrictions, we should always be able to load as a
 // legal equivalently-sized byte-typed vector instead. This method is
 // responsible for re-expressing a ISD::LOAD via a correctly-aligned type. If
@@ -9420,6 +9440,9 @@ SDValue RISCVTargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
     // base of the authorizing capability. This is consistent with the
     // behaviour of Morello's CVT instruction when CCTLR.DDCBO is off.
     return emitCToPtrReplacement(DAG, DL, Op->getOperand(2), XLenVT);
+  case Intrinsic::cheri_cap_tag_clear:
+    return emitCClearTagReplacement(DAG, Subtarget, DL, Op.getOperand(1),
+                                    XLenVT);
   case Intrinsic::thread_pointer: {
     MCPhysReg PhysReg = RISCVABI::isCheriPureCapABI(Subtarget.getTargetABI())
         ? RISCV::C4 : RISCV::X4;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
@@ -384,6 +384,13 @@ def : PatGpcrGpcr<riscv_cap_equal_exact, SCEQ, XLenVT>;
 let Predicates = [HasZCheriPurecap, HasZCheriHybrid] in
 def : Pat<(int_cheri_ddc_get), (CHERI_CSRRC CSR_DDC.Encoding, (XLenVT X0))>;
 
+let Predicates = [HasZCheriHybrid, NotCapMode] in {
+  let Size = 12 in
+  def PseudoPCCGet : Pseudo<(outs GPCR:$dst), (ins), []>;
+
+  def : Pat<(int_cheri_pcc_get), (PseudoPCCGet)>;
+}
+
 /// Capability loads
 
 let Predicates = [HasZCheriPurecap, NotCapMode, HasStdExtD, IsRV32] in

--- a/llvm/test/CodeGen/CHERI-Generic/Inputs/intrinsics.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/Inputs/intrinsics.ll
@@ -146,12 +146,10 @@ define i8 addrspace(200)* @bounds_set_immediate(i8 addrspace(200)* %cap) nounwin
   ret i8 addrspace(200)* %newcap
 }
 
-#if !(defined(RISCV32BAKEWELL) | defined(RISCV64BAKEWELL))
 define i8 addrspace(200)* @tag_clear(i8 addrspace(200)* %cap) nounwind {
   %untagged = call i8 addrspace(200)* @llvm.cheri.cap.tag.clear(i8 addrspace(200)* %cap)
   ret i8 addrspace(200)* %untagged
 }
-#endif
 
 define i8 addrspace(200)* @build(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2) nounwind {
   %built = call i8 addrspace(200)* @llvm.cheri.cap.build(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2)

--- a/llvm/test/CodeGen/CHERI-Generic/Inputs/intrinsics.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/Inputs/intrinsics.ll
@@ -219,12 +219,12 @@ define i8 addrspace(200)* @ddc_get() nounwind {
   %cap = call i8 addrspace(200)* @llvm.cheri.ddc.get()
   ret i8 addrspace(200)* %cap
 }
+#endif
 
 define i8 addrspace(200)* @pcc_get() nounwind {
   %cap = call i8 addrspace(200)* @llvm.cheri.pcc.get()
   ret i8 addrspace(200)* %cap
 }
-#endif
 
 ; Assertion Instructions
 

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV32Bakewell/intrinsics.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV32Bakewell/intrinsics.ll
@@ -249,6 +249,21 @@ define i8 addrspace(200)* @bounds_set_immediate(i8 addrspace(200)* %cap) nounwin
   %newcap = call i8 addrspace(200)* @llvm.cheri.cap.bounds.set.i32(i8 addrspace(200)* %cap, i32 42)
   ret i8 addrspace(200)* %newcap
 }
+define i8 addrspace(200)* @tag_clear(i8 addrspace(200)* %cap) nounwind {
+; PURECAP-LABEL: tag_clear:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    gchi a1, ca0
+; PURECAP-NEXT:    schi ca0, ca0, a1
+; PURECAP-NEXT:    ret
+;
+; HYBRID-LABEL: tag_clear:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    gchi a1, ca0
+; HYBRID-NEXT:    schi ca0, ca0, a1
+; HYBRID-NEXT:    ret
+  %untagged = call i8 addrspace(200)* @llvm.cheri.cap.tag.clear(i8 addrspace(200)* %cap)
+  ret i8 addrspace(200)* %untagged
+}
 define i8 addrspace(200)* @build(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2) nounwind {
 ; PURECAP-LABEL: build:
 ; PURECAP:       # %bb.0:
@@ -301,21 +316,21 @@ define i32 @to_pointer(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2) nounw
 define i8 addrspace(200)* @from_pointer(i8 addrspace(200)* %cap, i32 %ptr) nounwind {
 ; PURECAP-LABEL: from_pointer:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bnez a1, .LBB19_2
+; PURECAP-NEXT:    bnez a1, .LBB20_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmv ca0, cnull
 ; PURECAP-NEXT:    ret
-; PURECAP-NEXT:  .LBB19_2:
+; PURECAP-NEXT:  .LBB20_2:
 ; PURECAP-NEXT:    scaddr ca0, ca0, a1
 ; PURECAP-NEXT:    ret
 ;
 ; HYBRID-LABEL: from_pointer:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bnez a1, .LBB19_2
+; HYBRID-NEXT:    bnez a1, .LBB20_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmv ca0, cnull
 ; HYBRID-NEXT:    ret
-; HYBRID-NEXT:  .LBB19_2:
+; HYBRID-NEXT:  .LBB20_2:
 ; HYBRID-NEXT:    scaddr ca0, ca0, a1
 ; HYBRID-NEXT:    ret
   %newcap = call i8 addrspace(200)* @llvm.cheri.cap.from.pointer(i8 addrspace(200)* %cap, i32 %ptr)

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV32Bakewell/intrinsics.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV32Bakewell/intrinsics.ll
@@ -334,6 +334,21 @@ define i32 @diff(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2) nounwind {
   %diff = call i32 @llvm.cheri.cap.diff(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2)
   ret i32 %diff
 }
+define i8 addrspace(200)* @pcc_get() nounwind {
+; PURECAP-LABEL: pcc_get:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    auipc ca0, 0
+; PURECAP-NEXT:    ret
+;
+; HYBRID-LABEL: pcc_get:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    modesw.cap
+; HYBRID-NEXT:    auipc ca0, 0
+; HYBRID-NEXT:    modesw.int
+; HYBRID-NEXT:    ret
+  %cap = call i8 addrspace(200)* @llvm.cheri.pcc.get()
+  ret i8 addrspace(200)* %cap
+}
 ; Assertion Instructions
 declare i1 @llvm.cheri.cap.subset.test(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2)
 define i32 @subset_test(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2) nounwind {

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV64Bakewell/intrinsics.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV64Bakewell/intrinsics.ll
@@ -249,6 +249,21 @@ define i8 addrspace(200)* @bounds_set_immediate(i8 addrspace(200)* %cap) nounwin
   %newcap = call i8 addrspace(200)* @llvm.cheri.cap.bounds.set.i64(i8 addrspace(200)* %cap, i64 42)
   ret i8 addrspace(200)* %newcap
 }
+define i8 addrspace(200)* @tag_clear(i8 addrspace(200)* %cap) nounwind {
+; PURECAP-LABEL: tag_clear:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    gchi a1, ca0
+; PURECAP-NEXT:    schi ca0, ca0, a1
+; PURECAP-NEXT:    ret
+;
+; HYBRID-LABEL: tag_clear:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    gchi a1, ca0
+; HYBRID-NEXT:    schi ca0, ca0, a1
+; HYBRID-NEXT:    ret
+  %untagged = call i8 addrspace(200)* @llvm.cheri.cap.tag.clear(i8 addrspace(200)* %cap)
+  ret i8 addrspace(200)* %untagged
+}
 define i8 addrspace(200)* @build(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2) nounwind {
 ; PURECAP-LABEL: build:
 ; PURECAP:       # %bb.0:
@@ -301,21 +316,21 @@ define i64 @to_pointer(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2) nounw
 define i8 addrspace(200)* @from_pointer(i8 addrspace(200)* %cap, i64 %ptr) nounwind {
 ; PURECAP-LABEL: from_pointer:
 ; PURECAP:       # %bb.0:
-; PURECAP-NEXT:    bnez a1, .LBB19_2
+; PURECAP-NEXT:    bnez a1, .LBB20_2
 ; PURECAP-NEXT:  # %bb.1:
 ; PURECAP-NEXT:    cmv ca0, cnull
 ; PURECAP-NEXT:    ret
-; PURECAP-NEXT:  .LBB19_2:
+; PURECAP-NEXT:  .LBB20_2:
 ; PURECAP-NEXT:    scaddr ca0, ca0, a1
 ; PURECAP-NEXT:    ret
 ;
 ; HYBRID-LABEL: from_pointer:
 ; HYBRID:       # %bb.0:
-; HYBRID-NEXT:    bnez a1, .LBB19_2
+; HYBRID-NEXT:    bnez a1, .LBB20_2
 ; HYBRID-NEXT:  # %bb.1:
 ; HYBRID-NEXT:    cmv ca0, cnull
 ; HYBRID-NEXT:    ret
-; HYBRID-NEXT:  .LBB19_2:
+; HYBRID-NEXT:  .LBB20_2:
 ; HYBRID-NEXT:    scaddr ca0, ca0, a1
 ; HYBRID-NEXT:    ret
   %newcap = call i8 addrspace(200)* @llvm.cheri.cap.from.pointer(i8 addrspace(200)* %cap, i64 %ptr)

--- a/llvm/test/CodeGen/CHERI-Generic/RISCV64Bakewell/intrinsics.ll
+++ b/llvm/test/CodeGen/CHERI-Generic/RISCV64Bakewell/intrinsics.ll
@@ -334,6 +334,21 @@ define i64 @diff(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2) nounwind {
   %diff = call i64 @llvm.cheri.cap.diff(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2)
   ret i64 %diff
 }
+define i8 addrspace(200)* @pcc_get() nounwind {
+; PURECAP-LABEL: pcc_get:
+; PURECAP:       # %bb.0:
+; PURECAP-NEXT:    auipc ca0, 0
+; PURECAP-NEXT:    ret
+;
+; HYBRID-LABEL: pcc_get:
+; HYBRID:       # %bb.0:
+; HYBRID-NEXT:    modesw.cap
+; HYBRID-NEXT:    auipc ca0, 0
+; HYBRID-NEXT:    modesw.int
+; HYBRID-NEXT:    ret
+  %cap = call i8 addrspace(200)* @llvm.cheri.pcc.get()
+  ret i8 addrspace(200)* %cap
+}
 ; Assertion Instructions
 declare i1 @llvm.cheri.cap.subset.test(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2)
 define i64 @subset_test(i8 addrspace(200)* %cap1, i8 addrspace(200)* %cap2) nounwind {


### PR DESCRIPTION
This addresses multiple problems encountered on RV64Y CheriBSD builds.

- `cheri_flags_get/set` must be enabled for zcherihybrid
- `cheri_tag_clear` is implemented and expanded to gchi + schi.
- Fix OTYPE definitions in intrinsics.h
- `cheri_pcc_get` is implemented for zcherihybrid and expands into modesw.cap + auipc + modesw.int
- Remove some duplicate ELF definitions