### PR TITLE
Fix undef weak GOT entries

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -983,7 +983,7 @@ void elf::addGotEntry(Symbol &sym) {
   // Otherwise, the value is either a link-time constant or the load base
   // plus a constant. For CHERI it always requires run-time initialisation,
   // with the exception of undef weak symbols.
-  if ((config->isCheriAbi && sym.isUndefWeak() && !config->isStatic) ||
+  if ((config->isCheriAbi && sym.isUndefWeak()) ||
       (!config->isCheriAbi && (!config->isPic || isAbsolute(sym))))
     in.got->addConstant({expr, type, off, 0, &sym});
   else

--- a/lld/ELF/SyntheticSections.cpp
+++ b/lld/ELF/SyntheticSections.cpp
@@ -686,7 +686,6 @@ GotSection::GotSection()
   numEntries = target->gotHeaderEntriesNum;
 }
 
-void GotSection::addConstant(const Relocation &r) { addReloc(r); }
 void GotSection::addEntry(const Symbol &sym) {
   // TODO: Separate out TLS IE entries for CHERI so we can pack them more
   // efficiently rather than consuming a whole capability-sized slot for an

--- a/lld/ELF/SyntheticSections.h
+++ b/lld/ELF/SyntheticSections.h
@@ -110,7 +110,7 @@ public:
   bool isNeeded() const override;
   void writeTo(uint8_t *buf) override;
 
-  void addConstant(const Relocation &r);
+  void addConstant(const Relocation &r) { addReloc(r); }
   void addEntry(const Symbol &sym);
   bool addTlsDescEntry(const Symbol &sym);
   bool addDynTlsEntry(const Symbol &sym);

--- a/lld/test/ELF/cheri/mips/undef-weak.s
+++ b/lld/test/ELF/cheri/mips/undef-weak.s
@@ -3,19 +3,24 @@
 # RUN: llvm-mc -triple=mips64 -mcpu=cheri128 -mattr=+cheri128 -filetype=obj %s -o %t.128.o
 # RUN: ld.lld %t.128.o -o %t.128
 # RUN: llvm-readobj --cap-relocs %t.128 | FileCheck --check-prefix=RELOC %s
-# RUN: llvm-readobj -x .data %t.128 | FileCheck --check-prefix=HEX128 %s
+# RUN: llvm-readobj -x .captable -x .data %t.128 | FileCheck --check-prefix=HEX128 %s
 
 # RUN: llvm-mc -triple=mips64 -mcpu=cheri256 -mattr=+cheri256 -filetype=obj %s -o %t.256.o
 # RUN: ld.lld %t.256.o -o %t.256
 # RUN: llvm-readobj --cap-relocs %t.256 | FileCheck --check-prefix=RELOC %s
-# RUN: llvm-readobj -x .data %t.256 | FileCheck --check-prefix=HEX256 %s
+# RUN: llvm-readobj -x .captable -x .data %t.256 | FileCheck --check-prefix=HEX256 %s
 
 # RELOC: There is no __cap_relocs section in the file.
 
+# HEX128-LABEL: section '.captable':
+# HEX128-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
 # HEX128-LABEL: section '.data':
 # HEX128-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
 # HEX128-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000003
 
+# HEX256-LABEL: section '.captable':
+# HEX256-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
+# HEX256-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
 # HEX256-LABEL: section '.data':
 # HEX256-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
 # HEX256-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
@@ -23,6 +28,8 @@
 # HEX256-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
 
 .weak undef_weak
+
+clcbi $c1, %captab20(undef_weak)($c1)
 
 .data
 .chericap undef_weak

--- a/lld/test/ELF/cheri/riscv/undef-weak.s
+++ b/lld/test/ELF/cheri/riscv/undef-weak.s
@@ -3,23 +3,30 @@
 # RUN: %riscv32_cheri_purecap_llvm-mc -filetype=obj %s -o %t.32.o
 # RUN: ld.lld %t.32.o -o %t.32
 # RUN: llvm-readobj --cap-relocs %t.32 | FileCheck --check-prefix=RELOC %s
-# RUN: llvm-readobj -x .data %t.32 | FileCheck --check-prefix=HEX32 %s
+# RUN: llvm-readobj -x .got -x .data %t.32 | FileCheck --check-prefix=HEX32 %s
 
 # RUN: %riscv64_cheri_purecap_llvm-mc -filetype=obj %s -o %t.64.o
 # RUN: ld.lld %t.64.o -o %t.64
 # RUN: llvm-readobj --cap-relocs %t.64 | FileCheck --check-prefix=RELOC %s
-# RUN: llvm-readobj -x .data %t.64 | FileCheck --check-prefix=HEX64 %s
+# RUN: llvm-readobj -x .got -x .data %t.64 | FileCheck --check-prefix=HEX64 %s
 
 # RELOC: There is no __cap_relocs section in the file.
 
+# HEX32-LABEL: section '.got':
+# HEX32-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
 # HEX32-LABEL: section '.data':
 # HEX32-NEXT:  [[#%x,]] 00000000 00000000 03000000 00000000
 
+# HEX64-LABEL: section '.got':
+# HEX64-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
+# HEX64-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
 # HEX64-LABEL: section '.data':
 # HEX64-NEXT:  [[#%x,]] 00000000 00000000 00000000 00000000
 # HEX64-NEXT:  [[#%x,]] 03000000 00000000 00000000 00000000
 
 .weak undef_weak
+
+clgc ca0, undef_weak
 
 .data
 .chericap undef_weak


### PR DESCRIPTION
- [ELF] Re-apply 2ab77b9827f6 ("[NFC][ELF] Don't reimplement addReloc in GotSection")
- Revert "[lld] Emit relative relocs for .got entries when statically linking"
