### PR TITLE
[RISCV/CHERI] Use late pseudo expansion for PCC get

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -70,6 +70,9 @@ private:
                              MachineBasicBlock::iterator MBBI,
                              MachineBasicBlock::iterator &NextMBBI);
   bool expandCGetAddr(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
+  bool expandCheriPccGetIntMode(MachineBasicBlock &MBB,
+                                MachineBasicBlock::iterator MBBI,
+                                MachineBasicBlock::iterator &NextMBBI);
   bool expandCCOp(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
                   MachineBasicBlock::iterator &NextMBBI);
   bool expandVSetVL(MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI);
@@ -141,6 +144,8 @@ bool RISCVExpandPseudo::expandMI(MachineBasicBlock &MBB,
     return expandCapLoadTLSIEAddress(MBB, MBBI, NextMBBI);
   case RISCV::PseudoCLC_TLS_GD:
     return expandCapLoadTLSGDCap(MBB, MBBI, NextMBBI);
+  case RISCV::PseudoCheriPccGetIntMode:
+    return expandCheriPccGetIntMode(MBB, MBBI, NextMBBI);
   case RISCV::PseudoRV32ZdinxSD:
     return expandRV32ZdinxStore(MBB, MBBI);
   case RISCV::PseudoRV32ZdinxLD:
@@ -307,6 +312,25 @@ bool RISCVExpandPseudo::expandCGetAddr(MachineBasicBlock &MBB,
       .addImm(0);
   MBBI->eraseFromParent(); // The pseudo instruction is gone now.
   return true;
+}
+
+bool RISCVExpandPseudo::expandCheriPccGetIntMode(
+    MachineBasicBlock &MBB, MachineBasicBlock::iterator MBBI,
+    MachineBasicBlock::iterator &NextMBBI) {
+  const auto &STI = MBB.getParent()->getSubtarget<RISCVSubtarget>();
+
+  if (STI.hasStdExtZCheriHybrid() && !STI.isCapMode()) {
+    Register DstReg = MBBI->getOperand(0).getReg();
+    DebugLoc DL = MBBI->getDebugLoc();
+
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::MODESW_CAP));
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::AUIPCC), DstReg).addImm(0);
+    BuildMI(MBB, MBBI, DL, TII->get(RISCV::MODESW_INT));
+    MBBI->eraseFromParent();
+    return true;
+  }
+
+  return false;
 }
 
 bool RISCVExpandPseudo::expandCCOp(MachineBasicBlock &MBB,

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -19338,32 +19338,12 @@ static MachineBasicBlock *emitFROUND(MachineInstr &MI, MachineBasicBlock *MBB,
   return DoneMBB;
 }
 
-static MachineBasicBlock *emitPCCGetIntMode(MachineInstr &MI,
-                                            MachineBasicBlock *MBB,
-                                            const RISCVSubtarget &Subtarget) {
-  DebugLoc DL = MI.getDebugLoc();
-  const RISCVInstrInfo &TII = *Subtarget.getInstrInfo();
-  Register DstReg = MI.getOperand(0).getReg();
-
-  // modesw.cap
-  // auipc $dst, 0
-  // modesw.int
-  BuildMI(*MBB, MI, DL, TII.get(RISCV::MODESW_CAP));
-  BuildMI(*MBB, MI, DL, TII.get(RISCV::AUIPCC), DstReg).addImm(0);
-  BuildMI(*MBB, MI, DL, TII.get(RISCV::MODESW_INT));
-
-  MI.eraseFromParent();
-  return MBB;
-}
-
 MachineBasicBlock *
 RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
                                                  MachineBasicBlock *BB) const {
   switch (MI.getOpcode()) {
   default:
     llvm_unreachable("Unexpected instr type to insert");
-  case RISCV::CheriPccGetIntMode:
-    return emitPCCGetIntMode(MI, BB, Subtarget);
   case RISCV::ReadCounterWide:
     assert(!Subtarget.is64Bit() &&
            "ReadCounterWide is only to be used on riscv32");

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
@@ -412,10 +412,10 @@ def : Pat<(int_cheri_ddc_get), (CHERI_CSRRC CSR_DDC.Encoding, (XLenVT X0))>;
 
 
 // Pseudo instruction to handle getting pcc when in integer mode
-let hasSideEffects = 0, mayLoad = 0, mayStore = 0, usesCustomInserter = 1 in
-def CheriPccGetIntMode : Pseudo<(outs GPCR:$rd), (ins), []>;
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0, Size = 12 in
+def PseudoCheriPccGetIntMode : Pseudo<(outs GPCR:$rd), (ins), []>;
 let Predicates = [HasZCheriHybrid, NotCapMode] in
-def : Pat<(int_cheri_pcc_get), (CheriPccGetIntMode)>;
+def : Pat<(int_cheri_pcc_get), (PseudoCheriPccGetIntMode)>;
 
 /// Capability loads
 

--- a/llvm/test/CodeGen/RISCV/cheri/bakewell/pcc-get-int-mode.ll
+++ b/llvm/test/CodeGen/RISCV/cheri/bakewell/pcc-get-int-mode.ll
@@ -9,9 +9,9 @@ define dso_local _ADDRTYPE_ @pccGetAddr() local_unnamed_addr {
 ; CHECK-NEXT:    .option capmode
 ; CHECK-NEXT:    modesw.cap
 ; CHECK-NEXT:    auipc ca0, 0
-; CHECK-NEXT:    mv a0, a0
 ; CHECK-NEXT:    .option nocapmode
 ; CHECK-NEXT:    modesw.int
+; CHECK-NEXT:    mv a0, a0
 ; CHECK-NEXT:    ret
   %1 = tail call ptr addrspace(200) @llvm.cheri.pcc.get()
   %2 = tail call _ADDRTYPE_ @llvm.cheri.cap.address.get._ADDRTYPE_(ptr addrspace(200) %1)


### PR DESCRIPTION
Early expansion results in the possibility of machine instructions being sunk/hoisted out of the modesw/auipcc/modesw pattern.