### PR TITLE
Add support for latest RVY mnemonics

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -392,6 +392,7 @@ struct RISCVOperand final : public MCParsedAsmOperand {
   struct RegOp {
     MCRegister RegNum;
     bool IsGPRAsFPR;
+    bool CoercedFromGPR;
   };
 
   struct ImmOp {
@@ -553,6 +554,38 @@ public:
   bool isGPCR() const {
     return Kind == KindTy::Register &&
            RISCVMCRegisterClasses[RISCV::GPCRRegClassID].contains(Reg.RegNum);
+  }
+
+  bool isYGPR() const { return isGPCR() && Reg.CoercedFromGPR; }
+
+  bool isYGPRNoX0() const { return isYGPR() && Reg.RegNum != RISCV::C0; }
+
+  bool isYGPRC() const {
+    return isYGPR() &&
+           RISCVMCRegisterClasses[RISCV::GPCRCRegClassID].contains(Reg.RegNum);
+  }
+
+  bool isYSP() const {
+    return isYGPR() &&
+           RISCVMCRegisterClasses[RISCV::CSPRegClassID].contains(Reg.RegNum);
+  }
+
+  bool isRVYCompatGPCR() const { return isGPCR(); }
+
+  bool isRVYCompatGPCRNoC0() const {
+    return isRVYCompatGPCR() && Reg.RegNum != RISCV::C0;
+  }
+
+  bool isRVYCompatGPCRC() const {
+    return RISCVMCRegisterClasses[RISCV::GPCRCRegClassID].contains(Reg.RegNum);
+  }
+
+  bool isRVYCompatGPCRTC() const {
+    return RISCVMCRegisterClasses[RISCV::GPCRTCRegClassID].contains(Reg.RegNum);
+  }
+
+  bool isRVYCompatCSP() const {
+    return RISCVMCRegisterClasses[RISCV::CSPRegClassID].contains(Reg.RegNum);
   }
 
   bool isGPRPair() const {
@@ -1314,6 +1347,7 @@ public:
     auto Op = std::make_unique<RISCVOperand>(KindTy::Register);
     Op->Reg.RegNum = Reg.id();
     Op->Reg.IsGPRAsFPR = IsGPRAsFPR;
+    Op->Reg.CoercedFromGPR = false;
     Op->StartLoc = S;
     Op->EndLoc = E;
     return Op;
@@ -1605,6 +1639,61 @@ unsigned RISCVAsmParser::validateTargetOperandClass(MCParsedAsmOperand &AsmOp,
     if (!Op.Reg.RegNum)
       return Match_InvalidOperand;
     return Match_Success;
+  }
+  // In RVY mode, capability registers can be referenced using unprefixed GPR
+  // register names (e.g. a0 instead of ca0). We coerce GPRs to GPCRs when
+  // the InstAlias uses the YGPR* (only allowing X registers) or RVYCompat*
+  // operand types (allowing both C and X registers).
+  const MCRegisterClass *RC = nullptr;
+  bool CoerceInAllModes = false;
+  switch (Kind) {
+  case MCK_YGPR:
+    RC = &RISCVMCRegisterClasses[RISCV::GPCRRegClassID];
+    CoerceInAllModes = true;
+    break;
+  case MCK_RVYCompatGPCR:
+  case MCK_RVYCompatZeroOffsetMemOpOperand:
+  case MCK_YGPRZeroOffsetMemOpOperand:
+    RC = &RISCVMCRegisterClasses[RISCV::GPCRRegClassID];
+    break;
+  case MCK_YGPRNoX0:
+    RC = &RISCVMCRegisterClasses[RISCV::GPCRNoC0RegClassID];
+    CoerceInAllModes = true;
+    break;
+  case MCK_RVYCompatGPCRNoC0:
+    RC = &RISCVMCRegisterClasses[RISCV::GPCRNoC0RegClassID];
+    break;
+  case MCK_YGPRC:
+    RC = &RISCVMCRegisterClasses[RISCV::GPCRCRegClassID];
+    CoerceInAllModes = true;
+    break;
+  case MCK_RVYCompatGPCRC:
+    RC = &RISCVMCRegisterClasses[RISCV::GPCRCRegClassID];
+    break;
+  case MCK_RVYCompatGPCRTC:
+    RC = &RISCVMCRegisterClasses[RISCV::GPCRTCRegClassID];
+    break;
+  case MCK_YSP:
+    RC = &RISCVMCRegisterClasses[RISCV::CSPRegClassID];
+    CoerceInAllModes = true;
+    break;
+  case MCK_RVYCompatCSP:
+    RC = &RISCVMCRegisterClasses[RISCV::CSPRegClassID];
+    break;
+  }
+  if (RC) {
+    // For the RVY mnemonics (MCK_Y*) we coerce in all modes, but for others,
+    // only capmode should accept x registers (instructions such as jalr, etc.)
+    bool ShouldCoerceGPR =
+        CoerceInAllModes || getSTI().hasFeature(RISCV::FeatureCapMode);
+    if (Op.isGPR() && ShouldCoerceGPR) {
+      MCRegister CapReg = convertGPRToGPCR(Reg);
+      if (!RC->contains(CapReg))
+        return getDiagKindFromRegisterClass((MatchClassKind)Kind);
+      Op.Reg.RegNum = CapReg;
+      Op.Reg.CoercedFromGPR = true;
+      return Match_Success;
+    }
   }
   return Match_InvalidOperand;
 }
@@ -1927,6 +2016,17 @@ bool RISCVAsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
     return Error(ErrorLoc, "immediate must be an integer in range [0, 31] "
                            "or be a multiple of 16 in the range [0, 496]");
   }
+  case Match_InvalidRVYCompatGPCR:
+  case Match_InvalidYGPR:
+  case Match_InvalidYGPRC:
+    return Error(Operands[ErrorInfo]->getStartLoc(), "operand must be a GPR");
+  case Match_InvalidRVYCompatGPCRNoC0:
+  case Match_InvalidYGPRNoX0:
+    return Error(Operands[ErrorInfo]->getStartLoc(),
+                 "operand must be a GPR other than x0");
+  case Match_InvalidRVYCompatCSP:
+  case Match_InvalidYSP:
+    return Error(Operands[ErrorInfo]->getStartLoc(), "operand must be sp");
   }
 
   llvm_unreachable("Unknown match type detected!");

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -62,7 +62,7 @@ def CheriZeroOffsetMemOpOperand : AsmOperandClass {
   let ParserMethod = "parseZeroOffsetMemOp";
 }
 
-def GPCRMemZeroOffset : RegisterOperand<GPCR> {
+def GPCRMemZeroOffset : MemOperand<GPCR> {
   let ParserMatchClass = CheriZeroOffsetMemOpOperand;
   let PrintMethod = "printZeroOffsetMemOp";
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -67,11 +67,46 @@ def GPCRMemZeroOffset : MemOperand<GPCR> {
   let PrintMethod = "printZeroOffsetMemOp";
 }
 
+def YGPRZeroOffsetMemOpOperand : AsmOperandClass {
+  let Name = "YGPRZeroOffsetMemOpOperand";
+  let RenderMethod = "addRegOperands";
+  let PredicateMethod = "isYGPR";
+  let ParserMethod = "parseZeroOffsetMemOp";
+  let DiagnosticType = "InvalidYGPR";
+}
+
+def YGPRMemZeroOffset : MemOperand<GPCR> {
+  let ParserMatchClass = YGPRZeroOffsetMemOpOperand;
+  let PrintMethod = "printZeroOffsetMemOp";
+}
+
+def RVYCompatZeroOffsetMemOpOperand : AsmOperandClass {
+  let Name = "RVYCompatZeroOffsetMemOpOperand";
+  let RenderMethod = "addRegOperands";
+  let PredicateMethod = "isRVYCompatGPCR";
+  let ParserMethod = "parseZeroOffsetMemOp";
+  let DiagnosticType = "InvalidRVYCompatGPCR";
+}
+
+def RVYCompatMemZeroOffset : MemOperand<GPCR> {
+  let ParserMatchClass = RVYCompatZeroOffsetMemOpOperand;
+  let PrintMethod = "printZeroOffsetMemOp";
+}
+
 def GPCRMem : MemOperand<GPCR>;
+def RVYCompatGPCRMem : MemOperand<GPCR> {
+  let ParserMatchClass = RVYCompatGPCROperand;
+}
 
 def CSPMem : MemOperand<CSP>;
+def RVYCompatCSPMem : MemOperand<CSP> {
+  let ParserMatchClass = RVYCompatCSPOperand;
+}
 
 def GPCRCMem : MemOperand<GPCRC>;
+def RVYCompatGPCRCMem : MemOperand<GPCRC> {
+  let ParserMatchClass = RVYCompatGPCRCOperand;
+}
 
 // A 9-bit unsigned immediate where the least significant four bits are zero.
 def uimm9_lsb0000 : Operand<XLenVT>,
@@ -221,7 +256,7 @@ multiclass CheriLoad_ri<bits<3> funct3, string opcodestr> {
   let hasSideEffects = 0, mayLoad = 1, mayStore = 0,
       DecoderNamespace = "CapModeOnly_" in
   def "" : RVInstI<funct3, OPC_LOAD, (outs GPR:$rd),
-                   (ins GPCRMem:$rs1, simm12:$imm12), opcodestr,
+                   (ins RVYCompatGPCRMem:$rs1, simm12:$imm12), opcodestr,
                    "$rd, ${imm12}(${rs1})">;
   def : InstAlias<"c" # opcodestr # " $rd, ${imm12}(${rs1})",
                   (!cast<Instruction>(NAME) GPR:$rd, GPCRMem:$rs1, simm12:$imm12),
@@ -232,7 +267,7 @@ multiclass CheriStore_ri<bits<3> funct3, string opcodestr> {
   let hasSideEffects = 0, mayLoad = 0, mayStore = 1,
       DecoderNamespace = "CapModeOnly_" in
   def "" : RVInstS<funct3, OPC_STORE, (outs),
-                   (ins GPR:$rs2, GPCRMem:$rs1, simm12:$imm12),
+                   (ins GPR:$rs2, RVYCompatGPCRMem:$rs1, simm12:$imm12),
                    opcodestr, "$rs2, ${imm12}(${rs1})">;
   def : InstAlias<"c" # opcodestr # "$rs2, ${imm12}(${rs1})",
                   (!cast<Instruction>(NAME) GPR:$rs2, GPCRMem:$rs1, simm12:$imm12),
@@ -245,7 +280,7 @@ multiclass CLR_r<bit aq, bit rl, bits<3> funct3, string opcodestr,
   let hasSideEffects = 0, mayLoad = 1, mayStore = 0,
       DecoderNamespace = Namespace in
   def "" : RVInstRAtomic<0b00010, aq, rl, funct3, OPC_AMO,
-                         (outs GPR:$rd), (ins GPCRMemZeroOffset:$rs1),
+                         (outs GPR:$rd), (ins RVYCompatMemZeroOffset:$rs1),
                          opcodestr, "$rd, $rs1"> {
     let rs2 = 0;
   }
@@ -267,7 +302,7 @@ multiclass CAMO_rr<bits<5> funct5, bit aq, bit rl, bits<3> funct3,
   let hasSideEffects = 0, mayLoad = 1, mayStore = 1,
       DecoderNamespace = Namespace in
   def "" : RVInstRAtomic<funct5, aq, rl, funct3, OPC_AMO,
-                         (outs GPR:$rd), (ins GPCRMemZeroOffset:$rs1, GPR:$rs2),
+                         (outs GPR:$rd), (ins RVYCompatMemZeroOffset:$rs1, GPR:$rs2),
                          opcodestr, "$rd, $rs2, $rs1">;
   def : InstAlias<"c" # opcodestr # "$rd, $rs2, $rs1",
                   (!cast<Instruction>(NAME) GPR:$rd, GPCRMemZeroOffset:$rs1,
@@ -354,26 +389,30 @@ multiclass CAMO_cas_aq_rl<bits<5> funct5, bits<3> funct3, string opcodestr,
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CCheriStackLoad<bits<3> funct3, string OpcodeStr,
-                      RegisterClass cls, DAGOperand opnd>
-    : RVInst16CI<funct3, 0b10, (outs cls:$rd), (ins CSPMem:$rs1, opnd:$imm),
+                      RegisterClass cls, DAGOperand opnd,
+                      DAGOperand rs1Operand = RVYCompatCSPMem>
+    : RVInst16CI<funct3, 0b10, (outs cls:$rd), (ins rs1Operand:$rs1, opnd:$imm),
                  OpcodeStr, "$rd, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CCheriStackStore<bits<3> funct3, string OpcodeStr,
-                       RegisterClass cls, DAGOperand opnd>
-    : RVInst16CSS<funct3, 0b10, (outs), (ins cls:$rs2, CSPMem:$rs1, opnd:$imm),
+                       RegisterClass cls, DAGOperand opnd,
+                       DAGOperand rs1Operand = RVYCompatCSPMem>
+    : RVInst16CSS<funct3, 0b10, (outs), (ins cls:$rs2, rs1Operand:$rs1, opnd:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CCheriLoad_ri<bits<3> funct3, string OpcodeStr,
-                    RegisterClass cls, DAGOperand opnd>
-    : RVInst16CL<funct3, 0b00, (outs cls:$rd), (ins GPCRCMem:$rs1, opnd:$imm),
+                    RegisterClass cls, DAGOperand opnd,
+                    DAGOperand rs1Operand = RVYCompatGPCRCMem>
+    : RVInst16CL<funct3, 0b00, (outs cls:$rd), (ins rs1Operand:$rs1, opnd:$imm),
                  OpcodeStr, "$rd, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CCheriStore_rri<bits<3> funct3, string OpcodeStr,
-                      RegisterClass cls, DAGOperand opnd>
-    : RVInst16CS<funct3, 0b00, (outs), (ins cls:$rs2, GPCRCMem:$rs1, opnd:$imm),
+                      RegisterClass cls, DAGOperand opnd,
+                      DAGOperand rs1Operand = RVYCompatGPCRCMem>
+    : RVInst16CS<funct3, 0b00, (outs), (ins cls:$rs2, rs1Operand:$rs1, opnd:$imm),
                  OpcodeStr, "$rs2, ${imm}(${rs1})">;
 
 //===----------------------------------------------------------------------===//
@@ -383,26 +422,26 @@ class CCheriStore_rri<bits<3> funct3, string OpcodeStr,
 let Predicates = [HasCheri] in {
 def CGetPerm   : Cheri_r<0x0, "cgetperm">;
 def : InstAlias<"gcperm $rd, $rs1", (CGetPerm GPR:$rd, GPCR:$rs1), 0>;
-def : InstAlias<"ypermr $rd, $rs1", (CGetPerm GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ypermr $rd, $rs1", (CGetPerm GPR:$rd, YGPR:$rs1), 0>;
 def CGetType   : Cheri_r<0x1, "cgettype">;
 def : InstAlias<"gctype $rd, $rs1", (CGetType GPR:$rd, GPCR:$rs1), 0>;
-def : InstAlias<"ytyper $rd, $rs1", (CGetType GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ytyper $rd, $rs1", (CGetType GPR:$rd, YGPR:$rs1), 0>;
 def CGetBase   : Cheri_r<0x2, "cgetbase">;
 def : InstAlias<"gcbase $rd, $rs1", (CGetBase GPR:$rd, GPCR:$rs1), 0>;
-def : InstAlias<"ybaser $rd, $rs1", (CGetBase GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ybaser $rd, $rs1", (CGetBase GPR:$rd, YGPR:$rs1), 0>;
 def CGetLen    : Cheri_r<0x3, "cgetlen">;
 def : InstAlias<"gclen $rd, $rs1", (CGetLen GPR:$rd, GPCR:$rs1), 0>;
-def : InstAlias<"ylenr $rd, $rs1", (CGetLen GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ylenr $rd, $rs1", (CGetLen GPR:$rd, YGPR:$rs1), 0>;
 def CGetTag    : Cheri_r<0x4, "cgettag">;
 def : InstAlias<"gctag $rd, $rs1", (CGetTag GPR:$rd, GPCR:$rs1), 0>;
-def : InstAlias<"ytagr $rd, $rs1", (CGetTag GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ytagr $rd, $rs1", (CGetTag GPR:$rd, YGPR:$rs1), 0>;
 def CGetSealed : Cheri_r<0x5, "cgetsealed">;
 def CGetOffset : Cheri_r<0x6, "cgetoffset">;
 def CGetFlags  : Cheri_r<0x7, "cgetflags">;
 // NB: No alias for gcmode->cgetflags since the result is inverted.
 def CGetHigh   : Cheri_r<0x17, "cgethigh">;
 def : InstAlias<"gchi $rd, $rs1", (CGetHigh GPR:$rd, GPCR:$rs1), 0>;
-def : InstAlias<"yhir $rd, $rs1", (CGetHigh GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"yhir $rd, $rs1", (CGetHigh GPR:$rd, YGPR:$rs1), 0>;
 // For backwards compatibility we still accept cgetaddr from assembly.
 let mayStore = false, mayLoad = false, Size = 4, isCodeGenOnly = false,
 hasSideEffects = false in
@@ -425,16 +464,16 @@ def CSetFlags       : Cheri_rr<0xe, "csetflags">;
 def CSetOffset      : Cheri_rr<0xf, "csetoffset">;
 def CSetAddr        : Cheri_rr<0x10, "csetaddr">;
 def : InstAlias<"scaddr $rd, $rs1, $rs2", (CSetAddr GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
-def : InstAlias<"yaddrw $rd, $rs1, $rs2", (CSetAddr GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
+def : InstAlias<"yaddrw $rd, $rs1, $rs2", (CSetAddr YGPR:$rd, YGPR:$rs1, GPR:$rs2), 0>;
 def CSetHigh        : Cheri_rr<0x16, "csethigh">;
 def : InstAlias<"schi $rd, $rs1, $rs2", (CSetHigh GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
-def : InstAlias<"yhiw $rd, $rs1, $rs2", (CSetHigh GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
+def : InstAlias<"yhiw $rd, $rs1, $rs2", (CSetHigh YGPR:$rd, YGPR:$rs1, GPR:$rs2), 0>;
 let isReMaterializable = 1, isAsCheapAsAMove = 1 in
 def CIncOffset      : Cheri_rr<0x11, "cincoffset">;
 def : InstAlias<"add $cd, $cs1, $rs2",
                 (CIncOffset GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
 def : InstAlias<"yadd $cd, $cs1, $rs2",
-                (CIncOffset GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
+                (CIncOffset YGPR:$cd, YGPR:$cs1, GPR:$rs2), 0>;
 let isReMaterializable = 1, isAsCheapAsAMove = 1 in
 def CIncOffsetImm   : Cheri_ri<0x1, "cincoffset", 1>;
 def : InstAlias<"addi $cd, $cs1, $imm",
@@ -442,18 +481,18 @@ def : InstAlias<"addi $cd, $cs1, $imm",
 def : InstAlias<"add $cd, $cs1, $imm",
                 (CIncOffsetImm GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
 def : InstAlias<"yaddi $cd, $cs1, $imm",
-                (CIncOffsetImm GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
+                (CIncOffsetImm YGPR:$cd, YGPR:$cs1, simm12:$imm), 0>;
 def : InstAlias<"yadd $cd, $cs1, $imm",
-                (CIncOffsetImm GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
+                (CIncOffsetImm YGPR:$cd, YGPR:$cs1, simm12:$imm), 0>;
 def CSetBounds      : Cheri_rr<0x8, "csetbounds">;
 def : InstAlias<"scbndsr $cd, $cs1, $rs2",
                 (CSetBounds GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
-def : InstAlias<"ybndsrw $rd, $rs1, $rs2", (CSetBounds GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
+def : InstAlias<"ybndsrw $rd, $rs1, $rs2", (CSetBounds YGPR:$rd, YGPR:$rs1, GPR:$rs2), 0>;
 def CSetBoundsExact : Cheri_rr<0x9, "csetboundsexact">;
 def : InstAlias<"scbnds $cd, $cs1, $rs2",
                 (CSetBoundsExact GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
 def : InstAlias<"ybndsw $cd, $cs1, $rs2",
-                (CSetBoundsExact GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
+                (CSetBoundsExact YGPR:$cd, YGPR:$cs1, GPR:$rs2), 0>;
 def CSetBoundsImm   : Cheri_ri<0x2, "csetbounds", 0>;
 // TODO: should restrict the valid immediates for scbnds(i)
 def : InstAlias<"scbndsi $cd, $cs1, $imm",
@@ -461,22 +500,22 @@ def : InstAlias<"scbndsi $cd, $cs1, $imm",
 def : InstAlias<"scbnds $cd, $cs1, $imm",
                 (CSetBoundsImm GPCR:$cd, GPCR:$cs1, uimm12:$imm), 0>;
 def : InstAlias<"ybndsw $cd, $cs1, $imm",
-                (CSetBoundsImm GPCR:$cd, GPCR:$cs1, uimm12:$imm), 0>;
-def : InstAlias<"ybndswi $rd, $rs1, $imm", (CSetBoundsImm GPCR:$rd, GPCR:$rs1, uimm12:$imm), 0>;
+                (CSetBoundsImm YGPR:$cd, YGPR:$cs1, uimm12:$imm), 0>;
+def : InstAlias<"ybndswi $rd, $rs1, $imm", (CSetBoundsImm YGPR:$rd, YGPR:$rs1, uimm12:$imm), 0>;
 def CClearTag       : Cheri_r<0xb, "ccleartag", GPCR>;
 let defsCanBeSealed = 1 in
 def CBuildCap       : Cheri_rr<0x1d, "cbuildcap", GPCR, GPCR, GPCRC0IsDDC>;
 def : InstAlias<"cbld $cd, $cs1, $cs2",
                 (CBuildCap GPCR:$cd, GPCRNoC0:$cs1, GPCR:$cs2), 0>;
 def : InstAlias<"ybld $cd, $cs1, $cs2",
-                (CBuildCap GPCR:$cd, GPCRNoC0:$cs1, GPCR:$cs2), 0>;
+                (CBuildCap YGPR:$cd, YGPRNoX0:$cs1, YGPR:$cs2), 0>;
 def CCopyType       : Cheri_rr<0x1e, "ccopytype", GPCR, GPCR>;
 let defsCanBeSealed = 1 in
 def CCSeal          : Cheri_rr<0x1f, "ccseal", GPCR, GPCR>;
 let defsCanBeSealed = 1 in
 def CSealEntry      : Cheri_r<0x11, "csealentry", GPCR>;
 def : InstAlias<"sentry $rd, $rs1", (CSealEntry GPCR:$rd, GPCR:$rs1), 0>;
-def : InstAlias<"ysentry $rd, $rs1", (CSealEntry GPCR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ysentry $rd, $rs1", (CSealEntry YGPR:$rd, YGPR:$rs1), 0>;
 
 def : InstAlias<"cincoffsetimm $cd, $cs1, $imm",
                 (CIncOffsetImm GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
@@ -497,7 +536,7 @@ let isMoveReg = 1, isReMaterializable = 1, isAsCheapAsAMove = 1,
     defsCanBeSealed = 1 in
 def CMove       : Cheri_r<0xa, "cmove", GPCR>;
 def : InstAlias<"cmv $cd, $cs1", (CMove GPCR:$cd, GPCR:$cs1), 0>;
-def : InstAlias<"ymv $cd, $cs1", (CMove GPCR:$cd, GPCR:$cs1), 0>;
+def : InstAlias<"ymv $cd, $cs1", (CMove YGPR:$cd, YGPR:$cs1), 0>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -536,12 +575,12 @@ def CTestSubset : Cheri_rr<0x20, "ctestsubset", GPR, GPCR, GPCRC0IsDDC>;
 def : InstAlias<"scss $rd, $cs1, $cs2",
                 (CTestSubset GPR:$rd, GPCRNoC0:$cs1, GPCR:$cs2), 0>;
 def : InstAlias<"yss $rd, $cs1, $cs2",
-                (CTestSubset GPR:$rd, GPCRNoC0:$cs1, GPCR:$cs2), 0>;
+                (CTestSubset GPR:$rd, YGPRNoX0:$cs1, YGPR:$cs2), 0>;
 def CSEQX       : Cheri_rr<0x21, "csetequalexact", GPR, GPCR, GPCR>;
 
 def : InstAlias<"cseqx $rd, $cs1, $cs2", (CSEQX GPR:$rd, GPCR:$cs1, GPCR:$cs2)>;
 def : InstAlias<"sceq $rd, $cs1, $cs2", (CSEQX GPR:$rd, GPCR:$cs1, GPCR:$cs2), 0>;
-def : InstAlias<"yeq $rd, $cs1, $cs2", (CSEQX GPR:$rd, GPCR:$cs1, GPCR:$cs2), 0>;
+def : InstAlias<"yeq $rd, $cs1, $cs2", (CSEQX GPR:$rd, YGPR:$cs1, YGPR:$cs2), 0>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -754,13 +793,13 @@ def : InstAlias<"lc $rd, (${rs1})",
 def : InstAlias<"sc $rs2, (${rs1})",
                 (SC_64  GPCR:$rs2, GPR:$rs1, 0)>;
 def : InstAlias<"ly $rd, ${imm12}(${rs1})",
-                (LC_64  GPCR:$rd, GPR:$rs1, simm12:$imm12), 0>;
+                (LC_64  YGPR:$rd, GPR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
-                (SC_64  GPCR:$rs2, GPR:$rs1, simm12:$imm12), 0>;
+                (SC_64  YGPR:$rs2, GPR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"ly $rd, (${rs1})",
-                (LC_64  GPCR:$rd, GPR:$rs1, 0), 0>;
+                (LC_64  YGPR:$rd, GPR:$rs1, 0), 0>;
 def : InstAlias<"sy $rs2, (${rs1})",
-                (SC_64  GPCR:$rs2, GPR:$rs1, 0), 0>;
+                (SC_64  YGPR:$rs2, GPR:$rs1, 0), 0>;
 }
 }
 
@@ -781,13 +820,13 @@ def : InstAlias<"lc $rd, (${rs1})",
 def : InstAlias<"sc $rs2, (${rs1})",
                 (SC_128  GPCR:$rs2, GPR:$rs1, 0)>;
 def : InstAlias<"ly $rd, ${imm12}(${rs1})",
-                (LC_128  GPCR:$rd, GPR:$rs1, simm12:$imm12), 0>;
+                (LC_128  YGPR:$rd, GPR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
-                (SC_128  GPCR:$rs2, GPR:$rs1, simm12:$imm12), 0>;
+                (SC_128  YGPR:$rs2, GPR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"ly $rd, (${rs1})",
-                (LC_128  GPCR:$rd, GPR:$rs1, 0), 0>;
+                (LC_128  YGPR:$rd, GPR:$rs1, 0), 0>;
 def : InstAlias<"sy $rs2, (${rs1})",
-                (SC_128  GPCR:$rs2, GPR:$rs1, 0), 0>;
+                (SC_128  YGPR:$rs2, GPR:$rs1, 0), 0>;
 }
 }
 
@@ -811,11 +850,11 @@ defm AMOSWAP_C  : AMO_C_rr_aq_rl<"64", 0b00001, 0b011, "amoswap.c", GPCR>;
 }
 
 defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "LR_C", "_64",
-                         (? GPCR:$rd, GPRMemZeroOffset:$rs1)>;
+                         (? YGPR:$rd, GPRMemZeroOffset:$rs1)>;
 defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "SC_C", "_64",
-                         (? GPR:$rd, GPRMemZeroOffset:$rs1, GPCR:$rs2)>;
+                         (? GPR:$rd, GPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "AMOSWAP_C", "_64",
-                         (? GPCR:$rd, GPRMemZeroOffset:$rs1, GPCR:$rs2)>;
+                         (? YGPR:$rd, GPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 }
 
 let Predicates = [HasCheri, HasStdExtA, IsRV64, NotCapMode] in {
@@ -824,11 +863,11 @@ defm SC_C       : AMO_C_rr_aq_rl<"128", 0b00011, 0b100, "sc.c", GPR>;
 defm AMOSWAP_C  : AMO_C_rr_aq_rl<"128", 0b00001, 0b100, "amoswap.c", GPCR>;
 
 defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "LR_C", "_128",
-                         (? GPCR:$rd, GPRMemZeroOffset:$rs1)>;
+                         (? YGPR:$rd, GPRMemZeroOffset:$rs1)>;
 defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "SC_C", "_128",
-                         (? GPR:$rd, GPRMemZeroOffset:$rs1, GPCR:$rs2)>;
+                         (? GPR:$rd, GPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "AMOSWAP_C", "_128",
-                         (? GPCR:$rd, GPRMemZeroOffset:$rs1, GPCR:$rs2)>;
+                         (? YGPR:$rd, GPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -856,44 +895,65 @@ def CJALR : RVInstI<0b000, OPC_JALR, (outs GPCR:$rd),
 } // hasSideEffects = 0, mayLoad = 0, mayStore = 0
 } // DecoderNameSpace = "CapModeOnly_"
 
-// Expands to an instruction alias with and without a c prefix for loads/stores/jumps
 multiclass CPrefixedInstAlias<string Asm, dag Result, int Emit = 0> {
   def : InstAlias<"c" # Asm, Result, 0>;
   def : InstAlias<Asm, Result, Emit>;
 }
 def : MnemonicAlias<"auipcc", "auipc">;
 
+multiclass CoercingLoadAlias<string opcodestr, Instruction inst, RegisterClass rdClass> {
+  def : InstAlias<opcodestr # " $rd, (${rs1})", (inst rdClass:$rd, RVYCompatGPCRMem:$rs1, 0), 0>;
+  def : InstAlias<opcodestr # " $rd, ${offset}(${rs1})", (inst rdClass:$rd, RVYCompatGPCRMem:$rs1, simm12:$offset), 0>;
+  def : InstAlias<"c" # opcodestr # " $rd, (${rs1})", (inst rdClass:$rd, GPCRMem:$rs1, 0), 0>;
+  def : InstAlias<"c" # opcodestr # " $rd, ${offset}(${rs1})", (inst rdClass:$rd, GPCRMem:$rs1, simm12:$offset), 0>;
+}
+
+multiclass CoercingStoreAlias<string opcodestr, Instruction inst, RegisterClass rs2Class> {
+  def : InstAlias<opcodestr # " $rs2, (${rs1})", (inst rs2Class:$rs2, RVYCompatGPCRMem:$rs1, 0), 0>;
+  def : InstAlias<opcodestr # " $rs2, ${offset}(${rs1})", (inst rs2Class:$rs2, RVYCompatGPCRMem:$rs1, simm12:$offset), 0>;
+  def : InstAlias<"c" # opcodestr # " $rs2, (${rs1})", (inst rs2Class:$rs2, GPCRMem:$rs1, 0), 0>;
+  def : InstAlias<"c" # opcodestr # " $rs2, ${offset}(${rs1})", (inst rs2Class:$rs2, GPCRMem:$rs1, simm12:$offset), 0>;
+}
+
 let Predicates = [HasZCheriPurecapOrCheri, IsCapMode] in {
 // "cj" is the non-canonical form, but we provide this for completeness.
-def: InstAlias<"j $offset",    (CJAL C0, simm21_lsb0_jal:$offset), 1>;
-def: InstAlias<"cj $offset",   (CJAL C0, simm21_lsb0_jal:$offset), 0>;
-def: InstAlias<"jal $offset",  (CJAL C1, simm21_lsb0_jal:$offset), 1>;
-def: InstAlias<"cjal $offset", (CJAL C1, simm21_lsb0_jal:$offset), 0>;
-def: InstAlias<"cjal $rd, $offset", (CJAL GPCR:$rd, simm21_lsb0_jal:$offset), 0>;
-def: InstAlias<"cjalr $rd, ${offset}(${rs1})", (CJALR GPCR:$rd, GPCR:$rs1, simm12:$offset), 0>;
+def : InstAlias<"j $offset",    (CJAL C0, simm21_lsb0_jal:$offset), 1>;
+def : InstAlias<"cj $offset",   (CJAL C0, simm21_lsb0_jal:$offset), 0>;
+def : InstAlias<"jal $offset",  (CJAL C1, simm21_lsb0_jal:$offset), 1>;
+def : InstAlias<"cjal $offset", (CJAL C1, simm21_lsb0_jal:$offset), 0>;
+def : InstAlias<"jal $rd, $offset",
+                (CJAL RVYCompatGPCR:$rd, simm21_lsb0_jal:$offset), 0>;
+def : InstAlias<"cjal $rd, $offset",
+                (CJAL GPCR:$rd, simm21_lsb0_jal:$offset), 0>;
+def : InstAlias<"jalr $rd, ${offset}(${rs1})",
+                (CJALR RVYCompatGPCR:$rd, RVYCompatGPCR:$rs1, simm12:$offset), 0>;
+def : InstAlias<"cjalr $rd, ${offset}(${rs1})",
+                (CJALR GPCR:$rd, GPCR:$rs1, simm12:$offset), 0>;
 
 // Non-zero offset aliases of "cjalr" are the lowest weight, followed by the
 // two-register form, then the one-register forms and finally "cret".
-def: InstAlias<"jr $rs",                 (CJALR       C0, GPCR:$rs, 0), 3>;
-def: InstAlias<"cjr $rs",                (CJALR       C0, GPCR:$rs, 0), 0>;
-def: InstAlias<"jr ${offset}(${rs})",    (CJALR       C0, GPCR:$rs, simm12:$offset), 1>;
-def: InstAlias<"cjr ${offset}(${rs})",   (CJALR       C0, GPCR:$rs, simm12:$offset), 0>;
-def: InstAlias<"jalr $rs",               (CJALR       C1, GPCR:$rs, 0), 3>;
-def: InstAlias<"cjalr $rs",              (CJALR       C1, GPCR:$rs, 0), 0>;
-def: InstAlias<"jalr ${offset}(${rs})",  (CJALR       C1, GPCR:$rs, simm12:$offset), 1>;
-def: InstAlias<"cjalr ${offset}(${rs})", (CJALR       C1, GPCR:$rs, simm12:$offset), 0>;
-def: InstAlias<"jalr $rd, $rs",          (CJALR GPCR:$rd, GPCR:$rs, 0), 2>;
-def: InstAlias<"cjalr $rd, $rs",         (CJALR GPCR:$rd, GPCR:$rs, 0), 0>;
-def: InstAlias<"ret",                    (CJALR       C0,       C1, 0), 4>;
-def: InstAlias<"cret",                   (CJALR       C0,       C1, 0), 0>;
+def : InstAlias<"jr $rs",                 (CJALR                C0,  RVYCompatGPCR:$rs, 0), 3>;
+def : InstAlias<"cjr $rs",                (CJALR                C0,           GPCR:$rs, 0), 0>;
+def : InstAlias<"jr ${offset}(${rs})",    (CJALR                C0,  RVYCompatGPCR:$rs, simm12:$offset), 1>;
+def : InstAlias<"cjr ${offset}(${rs})",   (CJALR                C0,           GPCR:$rs, simm12:$offset), 0>;
+def : InstAlias<"jalr $rs",               (CJALR                C1,  RVYCompatGPCR:$rs, 0), 3>;
+def : InstAlias<"cjalr $rs",              (CJALR                C1,           GPCR:$rs, 0), 0>;
+def : InstAlias<"jalr ${offset}(${rs})",  (CJALR                C1,  RVYCompatGPCR:$rs, simm12:$offset), 1>;
+def : InstAlias<"cjalr ${offset}(${rs})", (CJALR                C1,           GPCR:$rs, simm12:$offset), 0>;
+def : InstAlias<"jalr $rd, $rs",          (CJALR RVYCompatGPCR:$rd,  RVYCompatGPCR:$rs, 0), 2>;
+def : InstAlias<"cjalr $rd, $rs",         (CJALR          GPCR:$rd,           GPCR:$rs, 0), 0>;
+def : InstAlias<"ret",                    (CJALR                C0,                 C1, 0), 4>;
+def : InstAlias<"cret",                   (CJALR                C0,                 C1, 0), 0>;
 
 // Non-canonical forms for jump targets also accepted by the assembler.
-def: InstAlias<"jr $rs, $offset",         (CJALR       C0, GPCR:$rs, simm12:$offset), 0>;
-def: InstAlias<"cjr $rs, $offset",        (CJALR       C0, GPCR:$rs, simm12:$offset), 0>;
-def: InstAlias<"jalr $rs, $offset",       (CJALR       C1, GPCR:$rs, simm12:$offset), 0>;
-def: InstAlias<"cjalr $rs, $offset",      (CJALR       C1, GPCR:$rs, simm12:$offset), 0>;
-def: InstAlias<"jalr $rd, $rs, $offset",  (CJALR GPCR:$rd, GPCR:$rs, simm12:$offset), 0>;
-def: InstAlias<"cjalr $rd, $rs, $offset", (CJALR GPCR:$rd, GPCR:$rs, simm12:$offset), 0>;
+def : InstAlias<"jr $rs, $offset",         (CJALR                C0, RVYCompatGPCR:$rs, simm12:$offset), 0>;
+def : InstAlias<"cjr $rs, $offset",        (CJALR                C0,          GPCR:$rs, simm12:$offset), 0>;
+def : InstAlias<"jalr $rs, $offset",       (CJALR                C1, RVYCompatGPCR:$rs, simm12:$offset), 0>;
+def : InstAlias<"cjalr $rs, $offset",      (CJALR                C1,          GPCR:$rs, simm12:$offset), 0>;
+def : InstAlias<"jalr $rd, $rs, $offset",  (CJALR RVYCompatGPCR:$rd, RVYCompatGPCR:$rs, simm12:$offset), 0>;
+def : InstAlias<"cjalr $rd, $rs, $offset", (CJALR          GPCR:$rd,          GPCR:$rs, simm12:$offset), 0>;
+// Allow both `auipc c1`/`auipc x1` for RVY 0.9.3 and RVY 1.0 compatibility.
+def : InstAlias<"auipc $rd, $imm20", (AUIPCC RVYCompatGPCR:$rd, uimm20_auipc:$imm20), 0>;
 } // Predicates = [HasZCheriPurecapOrCheri, IsCapMode]
 
 
@@ -932,18 +992,16 @@ def CSC_64  : RVInstS<0x3, OPC_STORE, (outs),
 def : InstAlias<"csc $rs2, ${imm12}(${rs1})",
                 (CSC_64  GPCR:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
 
-defm : CPrefixedInstAlias<"lc $rd, (${rs1})",
-                          (CLC_64  GPCR:$rd, GPCRMem:$rs1, 0)>;
-defm : CPrefixedInstAlias<"sc $rs2, (${rs1})",
-                          (CSC_64  GPCR:$rs2, GPCRMem:$rs1, 0)>;
+defm : CPrefixedInstAlias<"lc $rd, (${rs1})", (CLC_64 GPCR:$rd, GPCRMem:$rs1, 0)>;
+defm : CPrefixedInstAlias<"sc $rs2, (${rs1})", (CSC_64 GPCR:$rs2, GPCRMem:$rs1, 0)>;
 def : InstAlias<"ly $rd, ${imm12}(${rs1})",
-                (CLC_64  GPCR:$rd, GPCR:$rs1, simm12:$imm12), 0>;
+                (CLC_64  YGPR:$rd, YGPR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
-                (CSC_64  GPCR:$rs2, GPCR:$rs1, simm12:$imm12), 0>;
+                (CSC_64  YGPR:$rs2, YGPR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"ly $rd, (${rs1})",
-                (CLC_64  GPCR:$rd, GPCR:$rs1, 0), 0>;
+                (CLC_64  YGPR:$rd, YGPR:$rs1, 0), 0>;
 def : InstAlias<"sy $rs2, (${rs1})",
-                (CSC_64  GPCR:$rs2, GPCR:$rs1, 0), 0>;
+                (CSC_64  YGPR:$rs2, YGPR:$rs1, 0), 0>;
 }
 
 let Predicates = [HasCheri, IsRV64, IsCapMode] in {
@@ -963,36 +1021,34 @@ def CSC_128  : RVInstS<0x4, OPC_STORE, (outs),
 def : InstAlias<"csc $rs2, ${imm12}(${rs1})",
                 (CSC_128  GPCR:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
 
-defm : CPrefixedInstAlias<"lc $rd, (${rs1})",
-                          (CLC_128  GPCR:$rd, GPCRMem:$rs1, 0)>;
-defm : CPrefixedInstAlias<"sc $rs2, (${rs1})",
-                          (CSC_128  GPCR:$rs2, GPCRMem:$rs1, 0)>;
+defm : CPrefixedInstAlias<"lc $rd, (${rs1})", (CLC_128 GPCR:$rd, GPCRMem:$rs1, 0)>;
+defm : CPrefixedInstAlias<"sc $rs2, (${rs1})", (CSC_128 GPCR:$rs2, GPCRMem:$rs1, 0)>;
 def : InstAlias<"ly $rd, ${imm12}(${rs1})",
-                (CLC_128  GPCR:$rd, GPCR:$rs1, simm12:$imm12), 0>;
+                (CLC_128  YGPR:$rd, YGPR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
-                (CSC_128  GPCR:$rs2, GPCR:$rs1, simm12:$imm12), 0>;
+                (CSC_128  YGPR:$rs2, YGPR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"ly $rd, (${rs1})",
-                (CLC_128  GPCR:$rd, GPCR:$rs1, 0), 0>;
+                (CLC_128  YGPR:$rd, YGPR:$rs1, 0), 0>;
 def : InstAlias<"sy $rs2, (${rs1})",
-                (CSC_128  GPCR:$rs2, GPCR:$rs1, 0), 0>;
+                (CSC_128  YGPR:$rs2, YGPR:$rs1, 0), 0>;
 }
 
 let Predicates = [HasZCheriPurecapOrCheri, IsCapMode] in {
-defm : CPrefixedInstAlias<"lb $rd, (${rs1})", (CLB  GPR:$rd, GPCR:$rs1, 0)>;
-defm : CPrefixedInstAlias<"lh $rd, (${rs1})", (CLH  GPR:$rd, GPCR:$rs1, 0)>;
-defm : CPrefixedInstAlias<"lw $rd, (${rs1})", (CLW  GPR:$rd, GPCR:$rs1, 0)>;
-defm : CPrefixedInstAlias<"lbu $rd, (${rs1})", (CLBU  GPR:$rd, GPCR:$rs1, 0)>;
-defm : CPrefixedInstAlias<"lhu $rd, (${rs1})", (CLHU  GPR:$rd, GPCR:$rs1, 0)>;
+defm : CoercingLoadAlias<"lb", CLB, GPR>;
+defm : CoercingLoadAlias<"lh", CLH, GPR>;
+defm : CoercingLoadAlias<"lw", CLW, GPR>;
+defm : CoercingLoadAlias<"lbu", CLBU, GPR>;
+defm : CoercingLoadAlias<"lhu", CLHU, GPR>;
 
-defm : CPrefixedInstAlias<"sb $rs2, (${rs1})", (CSB  GPR:$rs2, GPCR:$rs1, 0)>;
-defm : CPrefixedInstAlias<"sh $rs2, (${rs1})", (CSH  GPR:$rs2, GPCR:$rs1, 0)>;
-defm : CPrefixedInstAlias<"sw $rs2, (${rs1})", (CSW  GPR:$rs2, GPCR:$rs1, 0)>;
+defm : CoercingStoreAlias<"sb", CSB, GPR>;
+defm : CoercingStoreAlias<"sh", CSH, GPR>;
+defm : CoercingStoreAlias<"sw", CSW, GPR>;
 } // Predicates = [HasZCheriPurecapOrCheri, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, IsRV64, IsCapMode] in {
-defm : CPrefixedInstAlias<"lwu $rd, (${rs1})", (CLWU  GPR:$rd, GPCR:$rs1, 0)>;
-defm : CPrefixedInstAlias<"ld $rd, (${rs1})", (CLD  GPR:$rd, GPCR:$rs1, 0)>;
-defm : CPrefixedInstAlias<"sd $rs2, (${rs1})", (CSD  GPR:$rs2, GPCR:$rs1, 0)>;
+defm : CoercingLoadAlias<"lwu", CLWU, GPR>;
+defm : CoercingLoadAlias<"ld", CLD, GPR>;
+defm : CoercingStoreAlias<"sd", CSD, GPR>;
 } // Predicates = [HasZCheriPurecapOrCheri, IsRV64, IsCapMode]
 
 /// 'A' (Atomic Instructions) extension
@@ -1042,11 +1098,11 @@ defm CSC_C       : CAMO_C_rr_aq_rl<"64", 0b00011, 0b011, "sc.c", GPR,
 defm CAMOSWAP_C  : CAMO_C_rr_aq_rl<"64", 0b00001, 0b011, "amoswap.c", GPCR,
                                    "RISCV32CapModeOnly_">;
 defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "CLR_C", "_64",
-                         (? GPCR:$rd, GPCRMemZeroOffset:$rs1)>;
+                         (? YGPR:$rd, YGPRMemZeroOffset:$rs1)>;
 defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "CSC_C", "_64",
-                         (? GPR:$rd, GPCRMemZeroOffset:$rs1, GPCR:$rs2)>;
+                         (? GPR:$rd, YGPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "CAMOSWAP_C", "_64",
-                         (? GPCR:$rd, GPCRMemZeroOffset:$rs1, GPCR:$rs2)>;
+                         (? YGPR:$rd, YGPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 }
 
 let Predicates = [HasCheri, HasStdExtA, IsRV64, IsCapMode] in {
@@ -1054,11 +1110,11 @@ defm CLR_C       : CLR_C_r_aq_rl<"128", 0b100, "lr.c">;
 defm CSC_C       : CAMO_C_rr_aq_rl<"128", 0b00011, 0b100, "sc.c", GPR>;
 defm CAMOSWAP_C  : CAMO_C_rr_aq_rl<"128", 0b00001, 0b100, "amoswap.c", GPCR>;
 defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "CLR_C", "_128",
-                         (? GPCR:$rd, GPCRMemZeroOffset:$rs1)>;
+                         (? YGPR:$rd, YGPRMemZeroOffset:$rs1)>;
 defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "CSC_C", "_128",
-                         (? GPR:$rd, GPCRMemZeroOffset:$rs1, GPCR:$rs2)>;
+                         (? GPR:$rd, YGPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "CAMOSWAP_C", "_128",
-                         (? GPCR:$rd, GPCRMemZeroOffset:$rs1, GPCR:$rs2)>;
+                         (? YGPR:$rd, YGPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 }
 
 /// Zacas (Atomic Compare-and-Swap)
@@ -1123,13 +1179,8 @@ def CFSW : RVInstS<0b010, OPC_STORE_FP, (outs),
                    (ins FPR32:$rs2, GPCRMem:$rs1, simm12:$imm12),
                    "fsw", "$rs2, ${imm12}(${rs1})">;
 
-defm : CPrefixedInstAlias<"flw $rd, (${rs1})", (CFLW FPR32:$rd, GPCRMem:$rs1, 0)>;
-defm : CPrefixedInstAlias<"fsw $rs2, (${rs1})",
-                          (CFSW FPR32:$rs2, GPCRMem:$rs1, 0)>;
-def : InstAlias<"cflw $rd, ${imm12}(${rs1})",
-                (CFLW FPR32:$rd, GPCRMem:$rs1, simm12:$imm12), 0>;
-def : InstAlias<"cfsw $rs2, ${imm12}(${rs1})",
-                (CFSW FPR32:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
+defm : CoercingLoadAlias<"flw", CFLW, FPR32>;
+defm : CoercingStoreAlias<"fsw", CFSW, FPR32>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasStdExtF, IsCapMode]
 
 /// 'D' (Single-Precision Floating-Point) extension
@@ -1138,22 +1189,17 @@ let Predicates = [HasZCheriPurecapOrCheri, HasStdExtD, IsCapMode] in {
 let DecoderNamespace = "CapModeOnly_",
     hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def CFLD : RVInstI<0b011, OPC_LOAD_FP, (outs FPR64:$rd),
-                   (ins GPCRMem:$rs1, simm12:$imm12),
+                   (ins RVYCompatGPCRMem:$rs1, simm12:$imm12),
                    "fld", "$rd, ${imm12}(${rs1})">;
 
 let DecoderNamespace = "CapModeOnly_",
     hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def CFSD : RVInstS<0b011, OPC_STORE_FP, (outs),
-                   (ins FPR64:$rs2, GPCRMem:$rs1, simm12:$imm12),
+                   (ins FPR64:$rs2, RVYCompatGPCRMem:$rs1, simm12:$imm12),
                    "fsd", "$rs2, ${imm12}(${rs1})">;
 
-defm : CPrefixedInstAlias<"fld $rd, (${rs1})", (CFLD FPR64:$rd, GPCRMem:$rs1, 0)>;
-defm : CPrefixedInstAlias<"fsd $rs2, (${rs1})",
-                          (CFSD FPR64:$rs2, GPCRMem:$rs1, 0)>;
-def : InstAlias<"cfld $rd, ${imm12}(${rs1})",
-                (CFLD FPR64:$rd, GPCRMem:$rs1, simm12:$imm12), 0>;
-def : InstAlias<"cfsd $rs2, ${imm12}(${rs1})",
-                (CFSD FPR64:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
+defm : CoercingLoadAlias<"fld", CFLD, FPR64>;
+defm : CoercingStoreAlias<"fsd", CFSD, FPR64>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasStdExtD, IsCapMode]
 
 /// 'C' (Compressed Instructions) extension
@@ -1181,7 +1227,7 @@ def C_CFLD : CCheriLoad_ri<0b001, "c.fld", FPR64C, uimm8_lsb000> {
 }
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in
-def C_CLC_128 : CCheriLoad_ri<0b001, "c.lc", GPCRC, uimm9_lsb0000> {
+def C_CLC_128 : CCheriLoad_ri<0b001, "c.lc", GPCRC, uimm9_lsb0000, GPCRCMem> {
   bits<9> imm;
   let Inst{12-11} = imm{5-4};
   let Inst{10} = imm{8};
@@ -1197,7 +1243,7 @@ def C_CLW : CCheriLoad_ri<0b010, "c.lw", GPRC, uimm7_lsb00> {
 
 let DecoderNamespace = "RISCV32CapModeOnly_",
     Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in
-def C_CLC_64 : CCheriLoad_ri<0b011, "c.lc", GPCRC, uimm8_lsb000> {
+def C_CLC_64 : CCheriLoad_ri<0b011, "c.lc", GPCRC, uimm8_lsb000, GPCRCMem> {
   bits<8> imm;
   let Inst{12-10} = imm{5-3};
   let Inst{6-5} = imm{7-6};
@@ -1219,7 +1265,7 @@ def C_CFSD : CCheriStore_rri<0b101, "c.fsd", FPR64C, uimm8_lsb000> {
 }
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in
-def C_CSC_128 : CCheriStore_rri<0b101, "c.sc", GPCRC, uimm9_lsb0000> {
+def C_CSC_128 : CCheriStore_rri<0b101, "c.sc", GPCRC, uimm9_lsb0000, GPCRCMem> {
   bits<9> imm;
   let Inst{12-11} = imm{5-4};
   let Inst{10} = imm{8};
@@ -1235,7 +1281,7 @@ def C_CSW : CCheriStore_rri<0b110, "c.sw", GPRC, uimm7_lsb00> {
 
 let DecoderNamespace = "RISCV32CapModeOnly_",
     Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]  in
-def C_CSC_64 : CCheriStore_rri<0b111, "c.sc", GPCRC, uimm8_lsb000> {
+def C_CSC_64 : CCheriStore_rri<0b111, "c.sc", GPCRC, uimm8_lsb000, GPCRCMem> {
   bits<8> imm;
   let Inst{12-10} = imm{5-3};
   let Inst{6-5} = imm{7-6};
@@ -1275,7 +1321,7 @@ def C_CFLDCSP : CCheriStackLoad<0b001, "c.fldsp", FPR64, uimm9_lsb000> {
 }
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in
-def C_CLCCSP_128 : CCheriStackLoad<0b001, "c.lcsp", GPCRNoC0, uimm10_lsb0000> {
+def C_CLCCSP_128 : CCheriStackLoad<0b001, "c.lcsp", GPCRNoC0, uimm10_lsb0000, CSPMem> {
   let Inst{6} = imm{4};
   let Inst{5-2} = imm{9-6};
 }
@@ -1287,7 +1333,7 @@ def C_CLWCSP : CCheriStackLoad<0b010, "c.lwsp", GPRNoX0, uimm8_lsb00> {
 
 let DecoderNamespace = "RISCV32CapModeOnly_",
     Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in
-def C_CLCCSP_64 : CCheriStackLoad<0b011, "c.lcsp", GPCRNoC0, uimm9_lsb000> {
+def C_CLCCSP_64 : CCheriStackLoad<0b011, "c.lcsp", GPCRNoC0, uimm9_lsb000, CSPMem> {
   let Inst{6-5} = imm{4-3};
   let Inst{4-2} = imm{8-6};
 }
@@ -1321,7 +1367,7 @@ def C_CFSDCSP : CCheriStackStore<0b101, "c.fsdsp", FPR64, uimm9_lsb000> {
 }
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in
-def C_CSCCSP_128 : CCheriStackStore<0b101, "c.scsp", GPCR, uimm10_lsb0000> {
+def C_CSCCSP_128 : CCheriStackStore<0b101, "c.scsp", GPCR, uimm10_lsb0000, CSPMem> {
   let Inst{12-11} = imm{5-4};
   let Inst{10-7}  = imm{9-6};
 }
@@ -1333,7 +1379,7 @@ def C_CSWCSP : CCheriStackStore<0b110, "c.swsp", GPR, uimm8_lsb00> {
 
 let DecoderNamespace = "RISCV32CapModeOnly_",
     Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in
-def C_CSCCSP_64 : CCheriStackStore<0b111, "c.scsp", GPCR, uimm9_lsb000> {
+def C_CSCCSP_64 : CCheriStackStore<0b111, "c.scsp", GPCR, uimm9_lsb000, CSPMem> {
   let Inst{12-10} = imm{5-3};
   let Inst{9-7}   = imm{8-6};
 }
@@ -1359,7 +1405,9 @@ def : InstAlias<"c.csw $rs2, ${imm}(${rs1})", (C_CSW GPRC:$rs2, GPCRC:$rs1, uimm
 def : InstAlias<"c.clwcsp $rd, ${imm}(${rs1})", (C_CLWCSP GPRNoX0:$rd, CSP:$rs1, uimm8_lsb00:$imm), 0>;
 def : InstAlias<"c.cswcsp $rs2, ${imm}(${rs1})", (C_CSWCSP GPR:$rs2, CSP:$rs1, uimm8_lsb00:$imm), 0>;
 def : InstAlias<"c.cjalr $rs1", (C_CJALR GPCRNoC0:$rs1), 0>;
+def : InstAlias<"c.jalr $rs1", (C_CJALR RVYCompatGPCRNoC0:$rs1)>;
 def : InstAlias<"c.cjr $rs1", (C_CJR GPCRNoC0:$rs1), 0>;
+def : InstAlias<"c.jr $rs1", (C_CJR RVYCompatGPCRNoC0:$rs1)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
 def : InstAlias<"c.cld $rd, ${imm}(${rs1})", (C_CLD GPRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm), 0>;
@@ -1367,23 +1415,23 @@ def : InstAlias<"c.csd $rs2, ${imm}(${rs1})", (C_CSD GPRC:$rs2, GPCRC:$rs1, uimm
 def : InstAlias<"c.cldcsp $rd, ${imm}(${rs1})", (C_CLDCSP GPRNoX0:$rd, CSP:$rs1, uimm9_lsb000:$imm), 0>;
 def : InstAlias<"c.csdcsp $rs2, ${imm}(${rs1})", (C_CSDCSP GPR:$rs2, CSP:$rs1, uimm9_lsb000:$imm), 0>;
 def : InstAlias<"c.csc $rs2, ${imm}(${rs1})", (C_CSC_128 GPCRC:$rs2, GPCRC:$rs1, uimm9_lsb0000:$imm), 0>;
-def : InstAlias<"c.sy $rs2, ${imm}(${rs1})", (C_CSC_128 GPCRC:$rs2, GPCRC:$rs1, uimm9_lsb0000:$imm), 0>;
+def : InstAlias<"c.sy $rs2, ${imm}(${rs1})", (C_CSC_128 YGPRC:$rs2, YGPRC:$rs1, uimm9_lsb0000:$imm), 0>;
 def : InstAlias<"c.csccsp $rs2, ${imm}(${rs1})", (C_CSCCSP_128 GPCR:$rs2, CSP:$rs1, uimm10_lsb0000:$imm), 0>;
-def : InstAlias<"c.sysp $rs2, ${imm}(${rs1})", (C_CSCCSP_128 GPCR:$rs2, CSP:$rs1, uimm10_lsb0000:$imm), 0>;
+def : InstAlias<"c.sysp $rs2, ${imm}(${rs1})", (C_CSCCSP_128 YGPRC:$rs2, YSP:$rs1, uimm10_lsb0000:$imm), 0>;
 def : InstAlias<"c.clc $rd, ${imm}(${rs1})", (C_CLC_128 GPCRC:$rd, GPCRC:$rs1, uimm9_lsb0000:$imm), 0>;
-def : InstAlias<"c.ly $rd, ${imm}(${rs1})", (C_CLC_128 GPCRC:$rd, GPCRC:$rs1, uimm9_lsb0000:$imm), 0>;
+def : InstAlias<"c.ly $rd, ${imm}(${rs1})", (C_CLC_128 YGPRC:$rd, YGPRC:$rs1, uimm9_lsb0000:$imm), 0>;
 def : InstAlias<"c.clccsp $rd, ${imm}(${rs1})", (C_CLCCSP_128 GPCRNoC0:$rd, CSP:$rs1, uimm10_lsb0000:$imm), 0>;
-def : InstAlias<"c.lysp $rd, ${imm}(${rs1})", (C_CLCCSP_128 GPCRNoC0:$rd, CSP:$rs1, uimm10_lsb0000:$imm), 0>;
+def : InstAlias<"c.lysp $rd, ${imm}(${rs1})", (C_CLCCSP_128 YGPRNoX0:$rd, YSP:$rs1, uimm10_lsb0000:$imm), 0>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
 def : InstAlias<"c.csc $rs2, ${imm}(${rs1})", (C_CSC_64 GPCRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm), 0>;
-def : InstAlias<"c.sy $rs2, ${imm}(${rs1})", (C_CSC_64 GPCRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm), 0>;
+def : InstAlias<"c.sy $rs2, ${imm}(${rs1})", (C_CSC_64 YGPRC:$rs2, YGPRC:$rs1, uimm8_lsb000:$imm), 0>;
 def : InstAlias<"c.csccsp $rs2, ${imm}(${rs1})", (C_CSCCSP_64 GPCR:$rs2, CSP:$rs1, uimm9_lsb000:$imm), 0>;
-def : InstAlias<"c.sysp $rs2, ${imm}(${rs1})", (C_CSCCSP_64 GPCR:$rs2, CSP:$rs1, uimm9_lsb000:$imm), 0>;
+def : InstAlias<"c.sysp $rs2, ${imm}(${rs1})", (C_CSCCSP_64 YGPRC:$rs2, YSP:$rs1, uimm9_lsb000:$imm), 0>;
 def : InstAlias<"c.clc $rd, ${imm}(${rs1})", (C_CLC_64 GPCRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm), 0>;
-def : InstAlias<"c.ly $rd, ${imm}(${rs1})", (C_CLC_64 GPCRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm), 0>;
+def : InstAlias<"c.ly $rd, ${imm}(${rs1})", (C_CLC_64 YGPRC:$rd, YGPRC:$rs1, uimm8_lsb000:$imm), 0>;
 def : InstAlias<"c.clccsp $rd, ${imm}(${rs1})", (C_CLCCSP_64 GPCRNoC0:$rd, CSP:$rs1, uimm9_lsb000:$imm), 0>;
-def : InstAlias<"c.lysp $rd, ${imm}(${rs1})", (C_CLCCSP_64 GPCRNoC0:$rd, CSP:$rs1, uimm9_lsb000:$imm), 0>;
+def : InstAlias<"c.lysp $rd, ${imm}(${rs1})", (C_CLCCSP_64 YGPRNoX0:$rd, YSP:$rs1, uimm9_lsb000:$imm), 0>;
 def : InstAlias<"c.cjal $offset", (C_CJAL simm12_lsb0:$offset), 0>;
 } // [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32,
@@ -2360,8 +2408,8 @@ def : CompressPat<(CIncOffsetImm GPCRC:$rd, CSP:$rs1, uimm10_lsb00nonzero:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode] in {
-def : CompressPat<(CFLD FPR64C:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm),
-                  (C_CFLD FPR64C:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CFLD FPR64C:$rd, RVYCompatGPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CFLD FPR64C:$rd, RVYCompatGPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
@@ -2370,8 +2418,8 @@ def : CompressPat<(CLC_128 GPCRC:$rd, GPCRCMem:$rs1, uimm9_lsb0000:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
-def : CompressPat<(CLW GPRC:$rd, GPCRCMem:$rs1, uimm7_lsb00:$imm),
-                  (C_CLW GPRC:$rd, GPCRCMem:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(CLW GPRC:$rd, RVYCompatGPCRCMem:$rs1, uimm7_lsb00:$imm),
+                  (C_CLW GPRC:$rd, RVYCompatGPCRCMem:$rs1, uimm7_lsb00:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
@@ -2380,13 +2428,13 @@ def : CompressPat<(CLC_64 GPCRC:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CLD GPRC:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm),
-                  (C_CLD GPRC:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CLD GPRC:$rd, RVYCompatGPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CLD GPRC:$rd, RVYCompatGPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode] in {
-def : CompressPat<(CFSD FPR64C:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm),
-                  (C_CFSD FPR64C:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CFSD FPR64C:$rs2, RVYCompatGPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CFSD FPR64C:$rs2, RVYCompatGPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
@@ -2395,8 +2443,8 @@ def : CompressPat<(CSC_128 GPCRC:$rs2, GPCRCMem:$rs1, uimm9_lsb0000:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
-def : CompressPat<(CSW GPRC:$rs2, GPCRCMem:$rs1, uimm7_lsb00:$imm),
-                  (C_CSW GPRC:$rs2, GPCRCMem:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(CSW GPRC:$rs2, RVYCompatGPCRCMem:$rs1, uimm7_lsb00:$imm),
+                  (C_CSW GPRC:$rs2, RVYCompatGPCRCMem:$rs1, uimm7_lsb00:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
@@ -2405,8 +2453,8 @@ def : CompressPat<(CSC_64 GPCRC:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CSD GPRC:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm),
-                  (C_CSD GPRC:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CSD GPRC:$rs2, RVYCompatGPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CSD GPRC:$rs2, RVYCompatGPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 // Quadrant 1
@@ -2427,8 +2475,8 @@ def : CompressPat<(CJAL C0, simm12_lsb0:$offset),
 
 // Quadrant 2
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode] in {
-def : CompressPat<(CFLD FPR64:$rd, CSPMem:$rs1, uimm9_lsb000:$imm),
-                  (C_CFLDCSP FPR64:$rd, CSPMem:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CFLD FPR64:$rd, RVYCompatCSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CFLDCSP FPR64:$rd, RVYCompatCSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
@@ -2437,8 +2485,8 @@ def : CompressPat<(CLC_128 GPCRNoC0:$rd, CSPMem:$rs1, uimm10_lsb0000:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
-def : CompressPat<(CLW GPRNoX0:$rd, CSPMem:$rs1,  uimm8_lsb00:$imm),
-                  (C_CLWCSP GPRNoX0:$rd, CSPMem:$rs1, uimm8_lsb00:$imm)>;
+def : CompressPat<(CLW GPRNoX0:$rd, RVYCompatCSPMem:$rs1,  uimm8_lsb00:$imm),
+                  (C_CLWCSP GPRNoX0:$rd, RVYCompatCSPMem:$rs1, uimm8_lsb00:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
@@ -2447,8 +2495,8 @@ def : CompressPat<(CLC_64 GPCRNoC0:$rd, CSPMem:$rs1, uimm9_lsb000:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CLD GPRNoX0:$rd, CSPMem:$rs1, uimm9_lsb000:$imm),
-                  (C_CLDCSP GPRNoX0:$rd, CSPMem:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CLD GPRNoX0:$rd, RVYCompatCSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CLDCSP GPRNoX0:$rd, RVYCompatCSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
@@ -2462,8 +2510,8 @@ def : CompressPat<(CJALR C1, GPCRNoC0:$rs1, 0),
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode] in {
-def : CompressPat<(CFSD FPR64:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm),
-                  (C_CFSDCSP FPR64:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CFSD FPR64:$rs2, RVYCompatCSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CFSDCSP FPR64:$rs2, RVYCompatCSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
@@ -2472,8 +2520,8 @@ def : CompressPat<(CSC_128 GPCR:$rs2, CSPMem:$rs1, uimm10_lsb0000:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
-def : CompressPat<(CSW GPR:$rs2, CSPMem:$rs1, uimm8_lsb00:$imm),
-                  (C_CSWCSP GPR:$rs2, CSPMem:$rs1, uimm8_lsb00:$imm)>;
+def : CompressPat<(CSW GPR:$rs2, RVYCompatCSPMem:$rs1, uimm8_lsb00:$imm),
+                  (C_CSWCSP GPR:$rs2, RVYCompatCSPMem:$rs1, uimm8_lsb00:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
@@ -2482,8 +2530,8 @@ def : CompressPat<(CSC_64 GPCR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CSD GPR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm),
-                  (C_CSDCSP GPR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CSD GPR:$rs2, RVYCompatCSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CSDCSP GPR:$rs2, RVYCompatCSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -859,24 +859,35 @@ def : MnemonicAlias<"auipcc", "auipc">;
 
 let Predicates = [HasZCheriPurecapOrCheri, IsCapMode] in {
 // "cj" is the non-canonical form, but we provide this for completeness.
-defm: CPrefixedInstAlias<"j $offset",   (CJAL C0, simm21_lsb0_jal:$offset), 1>;
-defm: CPrefixedInstAlias<"jal $offset", (CJAL C1, simm21_lsb0_jal:$offset), 1>;
+def: InstAlias<"j $offset",    (CJAL C0, simm21_lsb0_jal:$offset), 1>;
+def: InstAlias<"cj $offset",   (CJAL C0, simm21_lsb0_jal:$offset), 0>;
+def: InstAlias<"jal $offset",  (CJAL C1, simm21_lsb0_jal:$offset), 1>;
+def: InstAlias<"cjal $offset", (CJAL C1, simm21_lsb0_jal:$offset), 0>;
 def: InstAlias<"cjal $rd, $offset", (CJAL GPCR:$rd, simm21_lsb0_jal:$offset), 0>;
 def: InstAlias<"cjalr $rd, ${offset}(${rs1})", (CJALR GPCR:$rd, GPCR:$rs1, simm12:$offset), 0>;
 
 // Non-zero offset aliases of "cjalr" are the lowest weight, followed by the
 // two-register form, then the one-register forms and finally "cret".
-defm: CPrefixedInstAlias<"jr $rs",                (CJALR       C0, GPCR:$rs, 0), 3>;
-defm: CPrefixedInstAlias<"jr ${offset}(${rs})",   (CJALR       C0, GPCR:$rs, simm12:$offset), 1>;
-defm: CPrefixedInstAlias<"jalr $rs",              (CJALR       C1, GPCR:$rs, 0), 3>;
-defm: CPrefixedInstAlias<"jalr ${offset}(${rs})", (CJALR       C1, GPCR:$rs, simm12:$offset), 1>;
-defm: CPrefixedInstAlias<"jalr $rd, $rs",         (CJALR GPCR:$rd, GPCR:$rs, 0), 2>;
-defm: CPrefixedInstAlias<"ret",                   (CJALR       C0,       C1, 0), 4>;
+def: InstAlias<"jr $rs",                 (CJALR       C0, GPCR:$rs, 0), 3>;
+def: InstAlias<"cjr $rs",                (CJALR       C0, GPCR:$rs, 0), 0>;
+def: InstAlias<"jr ${offset}(${rs})",    (CJALR       C0, GPCR:$rs, simm12:$offset), 1>;
+def: InstAlias<"cjr ${offset}(${rs})",   (CJALR       C0, GPCR:$rs, simm12:$offset), 0>;
+def: InstAlias<"jalr $rs",               (CJALR       C1, GPCR:$rs, 0), 3>;
+def: InstAlias<"cjalr $rs",              (CJALR       C1, GPCR:$rs, 0), 0>;
+def: InstAlias<"jalr ${offset}(${rs})",  (CJALR       C1, GPCR:$rs, simm12:$offset), 1>;
+def: InstAlias<"cjalr ${offset}(${rs})", (CJALR       C1, GPCR:$rs, simm12:$offset), 0>;
+def: InstAlias<"jalr $rd, $rs",          (CJALR GPCR:$rd, GPCR:$rs, 0), 2>;
+def: InstAlias<"cjalr $rd, $rs",         (CJALR GPCR:$rd, GPCR:$rs, 0), 0>;
+def: InstAlias<"ret",                    (CJALR       C0,       C1, 0), 4>;
+def: InstAlias<"cret",                   (CJALR       C0,       C1, 0), 0>;
 
 // Non-canonical forms for jump targets also accepted by the assembler.
-defm: CPrefixedInstAlias<"jr $rs, $offset",        (CJALR       C0, GPCR:$rs, simm12:$offset), 0>;
-defm: CPrefixedInstAlias<"jalr $rs, $offset",      (CJALR       C1, GPCR:$rs, simm12:$offset), 0>;
-defm: CPrefixedInstAlias<"jalr $rd, $rs, $offset", (CJALR GPCR:$rd, GPCR:$rs, simm12:$offset), 0>;
+def: InstAlias<"jr $rs, $offset",         (CJALR       C0, GPCR:$rs, simm12:$offset), 0>;
+def: InstAlias<"cjr $rs, $offset",        (CJALR       C0, GPCR:$rs, simm12:$offset), 0>;
+def: InstAlias<"jalr $rs, $offset",       (CJALR       C1, GPCR:$rs, simm12:$offset), 0>;
+def: InstAlias<"cjalr $rs, $offset",      (CJALR       C1, GPCR:$rs, simm12:$offset), 0>;
+def: InstAlias<"jalr $rd, $rs, $offset",  (CJALR GPCR:$rd, GPCR:$rs, simm12:$offset), 0>;
+def: InstAlias<"cjalr $rd, $rs, $offset", (CJALR GPCR:$rd, GPCR:$rs, simm12:$offset), 0>;
 } // Predicates = [HasZCheriPurecapOrCheri, IsCapMode]
 
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -376,21 +376,27 @@ class CCheriStore_rri<bits<3> funct3, string OpcodeStr,
 
 let Predicates = [HasCheri] in {
 def CGetPerm   : Cheri_r<0x0, "cgetperm">;
-def : MnemonicAlias<"gcperm", "cgetperm">;
+def : InstAlias<"gcperm $rd, $rs1", (CGetPerm GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ypermr $rd, $rs1", (CGetPerm GPR:$rd, GPCR:$rs1), 0>;
 def CGetType   : Cheri_r<0x1, "cgettype">;
-def : MnemonicAlias<"gctype", "cgettype">;
+def : InstAlias<"gctype $rd, $rs1", (CGetType GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ytyper $rd, $rs1", (CGetType GPR:$rd, GPCR:$rs1), 0>;
 def CGetBase   : Cheri_r<0x2, "cgetbase">;
-def : MnemonicAlias<"gcbase", "cgetbase">;
+def : InstAlias<"gcbase $rd, $rs1", (CGetBase GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ybaser $rd, $rs1", (CGetBase GPR:$rd, GPCR:$rs1), 0>;
 def CGetLen    : Cheri_r<0x3, "cgetlen">;
-def : MnemonicAlias<"gclen", "cgetlen">;
+def : InstAlias<"gclen $rd, $rs1", (CGetLen GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ylenr $rd, $rs1", (CGetLen GPR:$rd, GPCR:$rs1), 0>;
 def CGetTag    : Cheri_r<0x4, "cgettag">;
-def : MnemonicAlias<"gctag", "cgettag">;
+def : InstAlias<"gctag $rd, $rs1", (CGetTag GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ytagr $rd, $rs1", (CGetTag GPR:$rd, GPCR:$rs1), 0>;
 def CGetSealed : Cheri_r<0x5, "cgetsealed">;
 def CGetOffset : Cheri_r<0x6, "cgetoffset">;
 def CGetFlags  : Cheri_r<0x7, "cgetflags">;
 // NB: No alias for gcmode->cgetflags since the result is inverted.
 def CGetHigh   : Cheri_r<0x17, "cgethigh">;
-def : MnemonicAlias<"gchi", "cgethigh">;
+def : InstAlias<"gchi $rd, $rs1", (CGetHigh GPR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"yhir $rd, $rs1", (CGetHigh GPR:$rd, GPCR:$rs1), 0>;
 // For backwards compatibility we still accept cgetaddr from assembly.
 let mayStore = false, mayLoad = false, Size = 4, isCodeGenOnly = false,
 hasSideEffects = false in
@@ -407,17 +413,21 @@ let defsCanBeSealed = 1 in
 def CSeal           : Cheri_rr<0xb, "cseal", GPCR, GPCR>;
 def CUnseal         : Cheri_rr<0xc, "cunseal", GPCR, GPCR>;
 def CAndPerm        : Cheri_rr<0xd, "candperm">;
-def : MnemonicAlias<"acperm", "candperm">;
+def : InstAlias<"acperm $rd, $rs1, $rs2", (CAndPerm GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
 def CSetFlags       : Cheri_rr<0xe, "csetflags">;
 // NB: No alias for scmode->csetflags since the argument is inverted.
 def CSetOffset      : Cheri_rr<0xf, "csetoffset">;
 def CSetAddr        : Cheri_rr<0x10, "csetaddr">;
-def : MnemonicAlias<"scaddr", "csetaddr">;
+def : InstAlias<"scaddr $rd, $rs1, $rs2", (CSetAddr GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
+def : InstAlias<"yaddrw $rd, $rs1, $rs2", (CSetAddr GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
 def CSetHigh        : Cheri_rr<0x16, "csethigh">;
-def : MnemonicAlias<"schi", "csethigh">;
+def : InstAlias<"schi $rd, $rs1, $rs2", (CSetHigh GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
+def : InstAlias<"yhiw $rd, $rs1, $rs2", (CSetHigh GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
 let isReMaterializable = 1, isAsCheapAsAMove = 1 in
 def CIncOffset      : Cheri_rr<0x11, "cincoffset">;
 def : InstAlias<"add $cd, $cs1, $rs2",
+                (CIncOffset GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
+def : InstAlias<"yadd $cd, $cs1, $rs2",
                 (CIncOffset GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
 let isReMaterializable = 1, isAsCheapAsAMove = 1 in
 def CIncOffsetImm   : Cheri_ri<0x1, "cincoffset", 1>;
@@ -425,11 +435,18 @@ def : InstAlias<"addi $cd, $cs1, $imm",
                 (CIncOffsetImm GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
 def : InstAlias<"add $cd, $cs1, $imm",
                 (CIncOffsetImm GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
+def : InstAlias<"yaddi $cd, $cs1, $imm",
+                (CIncOffsetImm GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
+def : InstAlias<"yadd $cd, $cs1, $imm",
+                (CIncOffsetImm GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
 def CSetBounds      : Cheri_rr<0x8, "csetbounds">;
 def : InstAlias<"scbndsr $cd, $cs1, $rs2",
                 (CSetBounds GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
+def : InstAlias<"ybndsrw $rd, $rs1, $rs2", (CSetBounds GPCR:$rd, GPCR:$rs1, GPR:$rs2), 0>;
 def CSetBoundsExact : Cheri_rr<0x9, "csetboundsexact">;
 def : InstAlias<"scbnds $cd, $cs1, $rs2",
+                (CSetBoundsExact GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
+def : InstAlias<"ybndsw $cd, $cs1, $rs2",
                 (CSetBoundsExact GPCR:$cd, GPCR:$cs1, GPR:$rs2), 0>;
 def CSetBoundsImm   : Cheri_ri<0x2, "csetbounds", 0>;
 // TODO: should restrict the valid immediates for scbnds(i)
@@ -437,17 +454,23 @@ def : InstAlias<"scbndsi $cd, $cs1, $imm",
                 (CSetBoundsImm GPCR:$cd, GPCR:$cs1, uimm12:$imm), 0>;
 def : InstAlias<"scbnds $cd, $cs1, $imm",
                 (CSetBoundsImm GPCR:$cd, GPCR:$cs1, uimm12:$imm), 0>;
+def : InstAlias<"ybndsw $cd, $cs1, $imm",
+                (CSetBoundsImm GPCR:$cd, GPCR:$cs1, uimm12:$imm), 0>;
+def : InstAlias<"ybndswi $rd, $rs1, $imm", (CSetBoundsImm GPCR:$rd, GPCR:$rs1, uimm12:$imm), 0>;
 def CClearTag       : Cheri_r<0xb, "ccleartag", GPCR>;
 let defsCanBeSealed = 1 in
 def CBuildCap       : Cheri_rr<0x1d, "cbuildcap", GPCR, GPCR, GPCRC0IsDDC>;
 def : InstAlias<"cbld $cd, $cs1, $cs2",
+                (CBuildCap GPCR:$cd, GPCRNoC0:$cs1, GPCR:$cs2), 0>;
+def : InstAlias<"ybld $cd, $cs1, $cs2",
                 (CBuildCap GPCR:$cd, GPCRNoC0:$cs1, GPCR:$cs2), 0>;
 def CCopyType       : Cheri_rr<0x1e, "ccopytype", GPCR, GPCR>;
 let defsCanBeSealed = 1 in
 def CCSeal          : Cheri_rr<0x1f, "ccseal", GPCR, GPCR>;
 let defsCanBeSealed = 1 in
 def CSealEntry      : Cheri_r<0x11, "csealentry", GPCR>;
-def : MnemonicAlias<"sentry", "csealentry">;
+def : InstAlias<"sentry $rd, $rs1", (CSealEntry GPCR:$rd, GPCR:$rs1), 0>;
+def : InstAlias<"ysentry $rd, $rs1", (CSealEntry GPCR:$rd, GPCR:$rs1), 0>;
 
 def : InstAlias<"cincoffsetimm $cd, $cs1, $imm",
                 (CIncOffsetImm GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
@@ -467,6 +490,8 @@ def PseudoCSub : Pseudo<(outs GPR:$rd), (ins GPCR:$cs1, GPCR:$cs2), [],
 let isMoveReg = 1, isReMaterializable = 1, isAsCheapAsAMove = 1,
     defsCanBeSealed = 1 in
 def CMove       : Cheri_r<0xa, "cmove", GPCR>;
+def : InstAlias<"cmv $cd, $cs1", (CMove GPCR:$cd, GPCR:$cs1), 0>;
+def : InstAlias<"ymv $cd, $cs1", (CMove GPCR:$cd, GPCR:$cs1), 0>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -504,10 +529,13 @@ let Predicates = [HasCheri] in {
 def CTestSubset : Cheri_rr<0x20, "ctestsubset", GPR, GPCR, GPCRC0IsDDC>;
 def : InstAlias<"scss $rd, $cs1, $cs2",
                 (CTestSubset GPR:$rd, GPCRNoC0:$cs1, GPCR:$cs2), 0>;
+def : InstAlias<"yss $rd, $cs1, $cs2",
+                (CTestSubset GPR:$rd, GPCRNoC0:$cs1, GPCR:$cs2), 0>;
 def CSEQX       : Cheri_rr<0x21, "csetequalexact", GPR, GPCR, GPCR>;
 
 def : InstAlias<"cseqx $rd, $cs1, $cs2", (CSEQX GPR:$rd, GPCR:$cs1, GPCR:$cs2)>;
 def : InstAlias<"sceq $rd, $cs1, $cs2", (CSEQX GPR:$rd, GPCR:$cs1, GPCR:$cs2), 0>;
+def : InstAlias<"yeq $rd, $cs1, $cs2", (CSEQX GPR:$rd, GPCR:$cs1, GPCR:$cs2), 0>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -545,6 +573,7 @@ def CRAM : Cheri_r<0x9, "crepresentablealignmentmask", GPR, GPR>;
 
 def : InstAlias<"crrl $rd, $rs1", (CRRL GPR:$rd, GPR:$rs1)>;
 def : InstAlias<"cram $rd, $rs1", (CRAM GPR:$rd, GPR:$rs1)>;
+def : InstAlias<"yamask $rd, $rs1", (CRAM GPR:$rd, GPR:$rs1), 0>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -718,6 +747,14 @@ def : InstAlias<"lc $rd, (${rs1})",
                 (LC_64  GPCR:$rd, GPR:$rs1, 0)>;
 def : InstAlias<"sc $rs2, (${rs1})",
                 (SC_64  GPCR:$rs2, GPR:$rs1, 0)>;
+def : InstAlias<"ly $rd, ${imm12}(${rs1})",
+                (LC_64  GPCR:$rd, GPR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
+                (SC_64  GPCR:$rs2, GPR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"ly $rd, (${rs1})",
+                (LC_64  GPCR:$rd, GPR:$rs1, 0), 0>;
+def : InstAlias<"sy $rs2, (${rs1})",
+                (SC_64  GPCR:$rs2, GPR:$rs1, 0), 0>;
 }
 }
 
@@ -737,20 +774,55 @@ def : InstAlias<"lc $rd, (${rs1})",
                 (LC_128  GPCR:$rd, GPR:$rs1, 0)>;
 def : InstAlias<"sc $rs2, (${rs1})",
                 (SC_128  GPCR:$rs2, GPR:$rs1, 0)>;
+def : InstAlias<"ly $rd, ${imm12}(${rs1})",
+                (LC_128  GPCR:$rd, GPR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
+                (SC_128  GPCR:$rs2, GPR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"ly $rd, (${rs1})",
+                (LC_128  GPCR:$rd, GPR:$rs1, 0), 0>;
+def : InstAlias<"sy $rs2, (${rs1})",
+                (SC_128  GPCR:$rs2, GPR:$rs1, 0), 0>;
 }
 }
 
-let DecoderNamespace = "RISCV32Only_",
-    Predicates = [HasCheri, HasStdExtA, IsRV32, NotCapMode] in {
+// Atomic instruction aliases multiclass for integer mode.
+multiclass AtomicInstAliases<string asm, string opnds, string inst, string sfx,
+                             dag args> {
+  def : InstAlias<asm#opnds, !con((!cast<Instruction>(inst#sfx)), args), 0>;
+  def : InstAlias<asm#".aq"#opnds,
+                  !con((!cast<Instruction>(inst#"_AQ"#sfx)), args), 0>;
+  def : InstAlias<asm#".rl"#opnds,
+                  !con((!cast<Instruction>(inst#"_RL"#sfx)), args), 0>;
+  def : InstAlias<asm#".aqrl"#opnds,
+                  !con((!cast<Instruction>(inst#"_AQ_RL"#sfx)), args), 0>;
+}
+
+let Predicates = [HasCheri, HasStdExtA, IsRV32, NotCapMode] in {
+let DecoderNamespace = "RISCV32Only_" in {
 defm LR_C       : LR_C_r_aq_rl<"64", 0b011, "lr.c">;
 defm SC_C       : AMO_C_rr_aq_rl<"64", 0b00011, 0b011, "sc.c", GPR>;
 defm AMOSWAP_C  : AMO_C_rr_aq_rl<"64", 0b00001, 0b011, "amoswap.c", GPCR>;
+}
+
+defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "LR_C", "_64",
+                         (? GPCR:$rd, GPRMemZeroOffset:$rs1)>;
+defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "SC_C", "_64",
+                         (? GPR:$rd, GPRMemZeroOffset:$rs1, GPCR:$rs2)>;
+defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "AMOSWAP_C", "_64",
+                         (? GPCR:$rd, GPRMemZeroOffset:$rs1, GPCR:$rs2)>;
 }
 
 let Predicates = [HasCheri, HasStdExtA, IsRV64, NotCapMode] in {
 defm LR_C       : LR_C_r_aq_rl<"128", 0b100, "lr.c">;
 defm SC_C       : AMO_C_rr_aq_rl<"128", 0b00011, 0b100, "sc.c", GPR>;
 defm AMOSWAP_C  : AMO_C_rr_aq_rl<"128", 0b00001, 0b100, "amoswap.c", GPCR>;
+
+defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "LR_C", "_128",
+                         (? GPCR:$rd, GPRMemZeroOffset:$rs1)>;
+defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "SC_C", "_128",
+                         (? GPR:$rd, GPRMemZeroOffset:$rs1, GPCR:$rs2)>;
+defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "AMOSWAP_C", "_128",
+                         (? GPCR:$rd, GPRMemZeroOffset:$rs1, GPCR:$rs2)>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -847,6 +919,14 @@ defm : CPrefixedInstAlias<"lc $rd, (${rs1})",
                           (CLC_64  GPCR:$rd, GPCR:$rs1, 0)>;
 defm : CPrefixedInstAlias<"sc $rs2, (${rs1})",
                           (CSC_64  GPCR:$rs2, GPCR:$rs1, 0)>;
+def : InstAlias<"ly $rd, ${imm12}(${rs1})",
+                (CLC_64  GPCR:$rd, GPCR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
+                (CSC_64  GPCR:$rs2, GPCR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"ly $rd, (${rs1})",
+                (CLC_64  GPCR:$rd, GPCR:$rs1, 0), 0>;
+def : InstAlias<"sy $rs2, (${rs1})",
+                (CSC_64  GPCR:$rs2, GPCR:$rs1, 0), 0>;
 }
 
 let Predicates = [HasCheri, IsRV64, IsCapMode] in {
@@ -870,6 +950,14 @@ defm : CPrefixedInstAlias<"lc $rd, (${rs1})",
                           (CLC_128  GPCR:$rd, GPCR:$rs1, 0)>;
 defm : CPrefixedInstAlias<"sc $rs2, (${rs1})",
                           (CSC_128  GPCR:$rs2, GPCR:$rs1, 0)>;
+def : InstAlias<"ly $rd, ${imm12}(${rs1})",
+                (CLC_128  GPCR:$rd, GPCR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
+                (CSC_128  GPCR:$rs2, GPCR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"ly $rd, (${rs1})",
+                (CLC_128  GPCR:$rd, GPCR:$rs1, 0), 0>;
+def : InstAlias<"sy $rs2, (${rs1})",
+                (CSC_128  GPCR:$rs2, GPCR:$rs1, 0), 0>;
 }
 
 let Predicates = [HasZCheriPurecapOrCheri, IsCapMode] in {
@@ -936,12 +1024,24 @@ defm CSC_C       : CAMO_C_rr_aq_rl<"64", 0b00011, 0b011, "sc.c", GPR,
                                    "RISCV32CapModeOnly_">;
 defm CAMOSWAP_C  : CAMO_C_rr_aq_rl<"64", 0b00001, 0b011, "amoswap.c", GPCR,
                                    "RISCV32CapModeOnly_">;
+defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "CLR_C", "_64",
+                         (? GPCR:$rd, GPCRMemZeroOffset:$rs1)>;
+defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "CSC_C", "_64",
+                         (? GPR:$rd, GPCRMemZeroOffset:$rs1, GPCR:$rs2)>;
+defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "CAMOSWAP_C", "_64",
+                         (? GPCR:$rd, GPCRMemZeroOffset:$rs1, GPCR:$rs2)>;
 }
 
 let Predicates = [HasCheri, HasStdExtA, IsRV64, IsCapMode] in {
 defm CLR_C       : CLR_C_r_aq_rl<"128", 0b100, "lr.c">;
 defm CSC_C       : CAMO_C_rr_aq_rl<"128", 0b00011, 0b100, "sc.c", GPR>;
 defm CAMOSWAP_C  : CAMO_C_rr_aq_rl<"128", 0b00001, 0b100, "amoswap.c", GPCR>;
+defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "CLR_C", "_128",
+                         (? GPCR:$rd, GPCRMemZeroOffset:$rs1)>;
+defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "CSC_C", "_128",
+                         (? GPR:$rd, GPCRMemZeroOffset:$rs1, GPCR:$rs2)>;
+defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "CAMOSWAP_C", "_128",
+                         (? GPCR:$rd, GPCRMemZeroOffset:$rs1, GPCR:$rs2)>;
 }
 
 /// Zacas (Atomic Compare-and-Swap)
@@ -1250,15 +1350,23 @@ def : InstAlias<"c.csd $rs2, ${imm}(${rs1})", (C_CSD GPRC:$rs2, GPCRC:$rs1, uimm
 def : InstAlias<"c.cldcsp $rd, ${imm}(${rs1})", (C_CLDCSP GPRNoX0:$rd, CSP:$rs1, uimm9_lsb000:$imm), 0>;
 def : InstAlias<"c.csdcsp $rs2, ${imm}(${rs1})", (C_CSDCSP GPR:$rs2, CSP:$rs1, uimm9_lsb000:$imm), 0>;
 def : InstAlias<"c.csc $rs2, ${imm}(${rs1})", (C_CSC_128 GPCRC:$rs2, GPCRC:$rs1, uimm9_lsb0000:$imm), 0>;
+def : InstAlias<"c.sy $rs2, ${imm}(${rs1})", (C_CSC_128 GPCRC:$rs2, GPCRC:$rs1, uimm9_lsb0000:$imm), 0>;
 def : InstAlias<"c.csccsp $rs2, ${imm}(${rs1})", (C_CSCCSP_128 GPCR:$rs2, CSP:$rs1, uimm10_lsb0000:$imm), 0>;
+def : InstAlias<"c.sysp $rs2, ${imm}(${rs1})", (C_CSCCSP_128 GPCR:$rs2, CSP:$rs1, uimm10_lsb0000:$imm), 0>;
 def : InstAlias<"c.clc $rd, ${imm}(${rs1})", (C_CLC_128 GPCRC:$rd, GPCRC:$rs1, uimm9_lsb0000:$imm), 0>;
+def : InstAlias<"c.ly $rd, ${imm}(${rs1})", (C_CLC_128 GPCRC:$rd, GPCRC:$rs1, uimm9_lsb0000:$imm), 0>;
 def : InstAlias<"c.clccsp $rd, ${imm}(${rs1})", (C_CLCCSP_128 GPCRNoC0:$rd, CSP:$rs1, uimm10_lsb0000:$imm), 0>;
+def : InstAlias<"c.lysp $rd, ${imm}(${rs1})", (C_CLCCSP_128 GPCRNoC0:$rd, CSP:$rs1, uimm10_lsb0000:$imm), 0>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
 def : InstAlias<"c.csc $rs2, ${imm}(${rs1})", (C_CSC_64 GPCRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm), 0>;
+def : InstAlias<"c.sy $rs2, ${imm}(${rs1})", (C_CSC_64 GPCRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm), 0>;
 def : InstAlias<"c.csccsp $rs2, ${imm}(${rs1})", (C_CSCCSP_64 GPCR:$rs2, CSP:$rs1, uimm9_lsb000:$imm), 0>;
+def : InstAlias<"c.sysp $rs2, ${imm}(${rs1})", (C_CSCCSP_64 GPCR:$rs2, CSP:$rs1, uimm9_lsb000:$imm), 0>;
 def : InstAlias<"c.clc $rd, ${imm}(${rs1})", (C_CLC_64 GPCRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm), 0>;
+def : InstAlias<"c.ly $rd, ${imm}(${rs1})", (C_CLC_64 GPCRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm), 0>;
 def : InstAlias<"c.clccsp $rd, ${imm}(${rs1})", (C_CLCCSP_64 GPCRNoC0:$rd, CSP:$rs1, uimm9_lsb000:$imm), 0>;
+def : InstAlias<"c.lysp $rd, ${imm}(${rs1})", (C_CLCCSP_64 GPCRNoC0:$rd, CSP:$rs1, uimm9_lsb000:$imm), 0>;
 def : InstAlias<"c.cjal $offset", (C_CJAL simm12_lsb0:$offset), 0>;
 } // [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCheri.td
@@ -67,6 +67,12 @@ def GPCRMemZeroOffset : MemOperand<GPCR> {
   let PrintMethod = "printZeroOffsetMemOp";
 }
 
+def GPCRMem : MemOperand<GPCR>;
+
+def CSPMem : MemOperand<CSP>;
+
+def GPCRCMem : MemOperand<GPCRC>;
+
 // A 9-bit unsigned immediate where the least significant four bits are zero.
 def uimm9_lsb0000 : Operand<XLenVT>,
                     ImmLeaf<XLenVT, [{return isShiftedUInt<5, 4>(Imm);}]> {
@@ -215,10 +221,10 @@ multiclass CheriLoad_ri<bits<3> funct3, string opcodestr> {
   let hasSideEffects = 0, mayLoad = 1, mayStore = 0,
       DecoderNamespace = "CapModeOnly_" in
   def "" : RVInstI<funct3, OPC_LOAD, (outs GPR:$rd),
-                   (ins GPCR:$rs1, simm12:$imm12), opcodestr,
+                   (ins GPCRMem:$rs1, simm12:$imm12), opcodestr,
                    "$rd, ${imm12}(${rs1})">;
   def : InstAlias<"c" # opcodestr # " $rd, ${imm12}(${rs1})",
-                  (!cast<Instruction>(NAME) GPR:$rd, GPCR:$rs1, simm12:$imm12),
+                  (!cast<Instruction>(NAME) GPR:$rd, GPCRMem:$rs1, simm12:$imm12),
                   0>;
 }
 
@@ -226,10 +232,10 @@ multiclass CheriStore_ri<bits<3> funct3, string opcodestr> {
   let hasSideEffects = 0, mayLoad = 0, mayStore = 1,
       DecoderNamespace = "CapModeOnly_" in
   def "" : RVInstS<funct3, OPC_STORE, (outs),
-                   (ins GPR:$rs2, GPCR:$rs1, simm12:$imm12),
+                   (ins GPR:$rs2, GPCRMem:$rs1, simm12:$imm12),
                    opcodestr, "$rs2, ${imm12}(${rs1})">;
   def : InstAlias<"c" # opcodestr # "$rs2, ${imm12}(${rs1})",
-                  (!cast<Instruction>(NAME) GPR:$rs2, GPCR:$rs1, simm12:$imm12),
+                  (!cast<Instruction>(NAME) GPR:$rs2, GPCRMem:$rs1, simm12:$imm12),
                   0>;
 }
 
@@ -349,25 +355,25 @@ multiclass CAMO_cas_aq_rl<bits<5> funct5, bits<3> funct3, string opcodestr,
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CCheriStackLoad<bits<3> funct3, string OpcodeStr,
                       RegisterClass cls, DAGOperand opnd>
-    : RVInst16CI<funct3, 0b10, (outs cls:$rd), (ins CSP:$rs1, opnd:$imm),
+    : RVInst16CI<funct3, 0b10, (outs cls:$rd), (ins CSPMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rd, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CCheriStackStore<bits<3> funct3, string OpcodeStr,
                        RegisterClass cls, DAGOperand opnd>
-    : RVInst16CSS<funct3, 0b10, (outs), (ins cls:$rs2, CSP:$rs1, opnd:$imm),
+    : RVInst16CSS<funct3, 0b10, (outs), (ins cls:$rs2, CSPMem:$rs1, opnd:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CCheriLoad_ri<bits<3> funct3, string OpcodeStr,
                     RegisterClass cls, DAGOperand opnd>
-    : RVInst16CL<funct3, 0b00, (outs cls:$rd), (ins GPCRC:$rs1, opnd:$imm),
+    : RVInst16CL<funct3, 0b00, (outs cls:$rd), (ins GPCRCMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rd, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CCheriStore_rri<bits<3> funct3, string OpcodeStr,
                       RegisterClass cls, DAGOperand opnd>
-    : RVInst16CS<funct3, 0b00, (outs), (ins cls:$rs2, GPCRC:$rs1, opnd:$imm),
+    : RVInst16CS<funct3, 0b00, (outs), (ins cls:$rs2, GPCRCMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rs2, ${imm}(${rs1})">;
 
 //===----------------------------------------------------------------------===//
@@ -913,23 +919,23 @@ let Predicates = [HasCheri, IsRV32, IsCapMode] in {
 let DecoderNamespace = "RISCV32CapModeOnly_",
     hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def CLC_64  : RVInstI<0x3, OPC_LOAD, (outs GPCR:$rd),
-                      (ins GPCR:$rs1, simm12:$imm12),
+                      (ins GPCRMem:$rs1, simm12:$imm12),
                       "lc", "$rd, ${imm12}(${rs1})">;
 def : InstAlias<"clc $rd, ${imm12}(${rs1})",
-                (CLC_64  GPCR:$rd, GPCR:$rs1, simm12:$imm12), 0>;
+                (CLC_64  GPCR:$rd, GPCRMem:$rs1, simm12:$imm12), 0>;
 
 let DecoderNamespace = "RISCV32CapModeOnly_",
     hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def CSC_64  : RVInstS<0x3, OPC_STORE, (outs),
-                      (ins GPCR:$rs2, GPCR:$rs1, simm12:$imm12),
+                      (ins GPCR:$rs2, GPCRMem:$rs1, simm12:$imm12),
                       "sc", "$rs2, ${imm12}(${rs1})">;
 def : InstAlias<"csc $rs2, ${imm12}(${rs1})",
-                (CSC_64  GPCR:$rs2, GPCR:$rs1, simm12:$imm12), 0>;
+                (CSC_64  GPCR:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
 
 defm : CPrefixedInstAlias<"lc $rd, (${rs1})",
-                          (CLC_64  GPCR:$rd, GPCR:$rs1, 0)>;
+                          (CLC_64  GPCR:$rd, GPCRMem:$rs1, 0)>;
 defm : CPrefixedInstAlias<"sc $rs2, (${rs1})",
-                          (CSC_64  GPCR:$rs2, GPCR:$rs1, 0)>;
+                          (CSC_64  GPCR:$rs2, GPCRMem:$rs1, 0)>;
 def : InstAlias<"ly $rd, ${imm12}(${rs1})",
                 (CLC_64  GPCR:$rd, GPCR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
@@ -944,23 +950,23 @@ let Predicates = [HasCheri, IsRV64, IsCapMode] in {
 let DecoderNamespace = "CapModeOnly_",
     hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def CLC_128  : RVInstI<0x2, OPC_MISC_MEM, (outs GPCR:$rd),
-                       (ins GPCR:$rs1, simm12:$imm12),
+                       (ins GPCRMem:$rs1, simm12:$imm12),
                        "lc", "$rd, ${imm12}(${rs1})">;
 def : InstAlias<"clc $rd, ${imm12}(${rs1})",
-                (CLC_128  GPCR:$rd, GPCR:$rs1, simm12:$imm12), 0>;
+                (CLC_128  GPCR:$rd, GPCRMem:$rs1, simm12:$imm12), 0>;
 
 let DecoderNamespace = "CapModeOnly_",
     hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def CSC_128  : RVInstS<0x4, OPC_STORE, (outs),
-                       (ins GPCR:$rs2, GPCR:$rs1, simm12:$imm12),
+                       (ins GPCR:$rs2, GPCRMem:$rs1, simm12:$imm12),
                        "sc", "$rs2, ${imm12}(${rs1})">;
 def : InstAlias<"csc $rs2, ${imm12}(${rs1})",
-                (CSC_128  GPCR:$rs2, GPCR:$rs1, simm12:$imm12), 0>;
+                (CSC_128  GPCR:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
 
 defm : CPrefixedInstAlias<"lc $rd, (${rs1})",
-                          (CLC_128  GPCR:$rd, GPCR:$rs1, 0)>;
+                          (CLC_128  GPCR:$rd, GPCRMem:$rs1, 0)>;
 defm : CPrefixedInstAlias<"sc $rs2, (${rs1})",
-                          (CSC_128  GPCR:$rs2, GPCR:$rs1, 0)>;
+                          (CSC_128  GPCR:$rs2, GPCRMem:$rs1, 0)>;
 def : InstAlias<"ly $rd, ${imm12}(${rs1})",
                 (CLC_128  GPCR:$rd, GPCR:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
@@ -1108,22 +1114,22 @@ let Predicates = [HasZCheriPurecapOrCheri, HasStdExtF, IsCapMode] in {
 let DecoderNamespace = "CapModeOnly_",
     hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def CFLW : RVInstI<0b010, OPC_LOAD_FP, (outs FPR32:$rd),
-                   (ins GPCR:$rs1, simm12:$imm12),
+                   (ins GPCRMem:$rs1, simm12:$imm12),
                    "flw", "$rd, ${imm12}(${rs1})">;
 
 let DecoderNamespace = "CapModeOnly_",
     hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def CFSW : RVInstS<0b010, OPC_STORE_FP, (outs),
-                   (ins FPR32:$rs2, GPCR:$rs1, simm12:$imm12),
+                   (ins FPR32:$rs2, GPCRMem:$rs1, simm12:$imm12),
                    "fsw", "$rs2, ${imm12}(${rs1})">;
 
-defm : CPrefixedInstAlias<"flw $rd, (${rs1})", (CFLW FPR32:$rd, GPCR:$rs1, 0)>;
+defm : CPrefixedInstAlias<"flw $rd, (${rs1})", (CFLW FPR32:$rd, GPCRMem:$rs1, 0)>;
 defm : CPrefixedInstAlias<"fsw $rs2, (${rs1})",
-                          (CFSW FPR32:$rs2, GPCR:$rs1, 0)>;
+                          (CFSW FPR32:$rs2, GPCRMem:$rs1, 0)>;
 def : InstAlias<"cflw $rd, ${imm12}(${rs1})",
-                (CFLW FPR32:$rd, GPCR:$rs1, simm12:$imm12), 0>;
+                (CFLW FPR32:$rd, GPCRMem:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"cfsw $rs2, ${imm12}(${rs1})",
-                (CFSW FPR32:$rs2, GPCR:$rs1, simm12:$imm12), 0>;
+                (CFSW FPR32:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasStdExtF, IsCapMode]
 
 /// 'D' (Single-Precision Floating-Point) extension
@@ -1132,22 +1138,22 @@ let Predicates = [HasZCheriPurecapOrCheri, HasStdExtD, IsCapMode] in {
 let DecoderNamespace = "CapModeOnly_",
     hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 def CFLD : RVInstI<0b011, OPC_LOAD_FP, (outs FPR64:$rd),
-                   (ins GPCR:$rs1, simm12:$imm12),
+                   (ins GPCRMem:$rs1, simm12:$imm12),
                    "fld", "$rd, ${imm12}(${rs1})">;
 
 let DecoderNamespace = "CapModeOnly_",
     hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def CFSD : RVInstS<0b011, OPC_STORE_FP, (outs),
-                   (ins FPR64:$rs2, GPCR:$rs1, simm12:$imm12),
+                   (ins FPR64:$rs2, GPCRMem:$rs1, simm12:$imm12),
                    "fsd", "$rs2, ${imm12}(${rs1})">;
 
-defm : CPrefixedInstAlias<"fld $rd, (${rs1})", (CFLD FPR64:$rd, GPCR:$rs1, 0)>;
+defm : CPrefixedInstAlias<"fld $rd, (${rs1})", (CFLD FPR64:$rd, GPCRMem:$rs1, 0)>;
 defm : CPrefixedInstAlias<"fsd $rs2, (${rs1})",
-                          (CFSD FPR64:$rs2, GPCR:$rs1, 0)>;
+                          (CFSD FPR64:$rs2, GPCRMem:$rs1, 0)>;
 def : InstAlias<"cfld $rd, ${imm12}(${rs1})",
-                (CFLD FPR64:$rd, GPCR:$rs1, simm12:$imm12), 0>;
+                (CFLD FPR64:$rd, GPCRMem:$rs1, simm12:$imm12), 0>;
 def : InstAlias<"cfsd $rs2, ${imm12}(${rs1})",
-                (CFSD FPR64:$rs2, GPCR:$rs1, simm12:$imm12), 0>;
+                (CFSD FPR64:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasStdExtD, IsCapMode]
 
 /// 'C' (Compressed Instructions) extension
@@ -2354,53 +2360,53 @@ def : CompressPat<(CIncOffsetImm GPCRC:$rd, CSP:$rs1, uimm10_lsb00nonzero:$imm),
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode] in {
-def : CompressPat<(CFLD FPR64C:$rd, GPCRC:$rs1, uimm8_lsb000:$imm),
-                  (C_CFLD FPR64C:$rd, GPCRC:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CFLD FPR64C:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CFLD FPR64C:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CLC_128 GPCRC:$rd, GPCRC:$rs1, uimm9_lsb0000:$imm),
-                  (C_CLC_128 GPCRC:$rd, GPCRC:$rs1, uimm9_lsb0000:$imm)>;
+def : CompressPat<(CLC_128 GPCRC:$rd, GPCRCMem:$rs1, uimm9_lsb0000:$imm),
+                  (C_CLC_128 GPCRC:$rd, GPCRCMem:$rs1, uimm9_lsb0000:$imm)>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
-def : CompressPat<(CLW GPRC:$rd, GPCRC:$rs1, uimm7_lsb00:$imm),
-                  (C_CLW GPRC:$rd, GPCRC:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(CLW GPRC:$rd, GPCRCMem:$rs1, uimm7_lsb00:$imm),
+                  (C_CLW GPRC:$rd, GPCRCMem:$rs1, uimm7_lsb00:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
-def : CompressPat<(CLC_64 GPCRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm),
-                  (C_CLC_64 GPCRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CLC_64 GPCRC:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CLC_64 GPCRC:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CLD GPRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm),
-                  (C_CLD GPRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CLD GPRC:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CLD GPRC:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode] in {
-def : CompressPat<(CFSD FPR64C:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm),
-                  (C_CFSD FPR64C:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CFSD FPR64C:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CFSD FPR64C:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CSC_128 GPCRC:$rs2, GPCRC:$rs1, uimm9_lsb0000:$imm),
-                  (C_CSC_128 GPCRC:$rs2, GPCRC:$rs1, uimm9_lsb0000:$imm)>;
+def : CompressPat<(CSC_128 GPCRC:$rs2, GPCRCMem:$rs1, uimm9_lsb0000:$imm),
+                  (C_CSC_128 GPCRC:$rs2, GPCRCMem:$rs1, uimm9_lsb0000:$imm)>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
-def : CompressPat<(CSW GPRC:$rs2, GPCRC:$rs1, uimm7_lsb00:$imm),
-                  (C_CSW GPRC:$rs2, GPCRC:$rs1, uimm7_lsb00:$imm)>;
+def : CompressPat<(CSW GPRC:$rs2, GPCRCMem:$rs1, uimm7_lsb00:$imm),
+                  (C_CSW GPRC:$rs2, GPCRCMem:$rs1, uimm7_lsb00:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
-def : CompressPat<(CSC_64 GPCRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm),
-                  (C_CSC_64 GPCRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CSC_64 GPCRC:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CSC_64 GPCRC:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CSD GPRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm),
-                  (C_CSD GPRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CSD GPRC:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CSD GPRC:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 // Quadrant 1
@@ -2421,28 +2427,28 @@ def : CompressPat<(CJAL C0, simm12_lsb0:$offset),
 
 // Quadrant 2
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode] in {
-def : CompressPat<(CFLD FPR64:$rd, CSP:$rs1, uimm9_lsb000:$imm),
-                  (C_CFLDCSP FPR64:$rd, CSP:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CFLD FPR64:$rd, CSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CFLDCSP FPR64:$rd, CSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CLC_128 GPCRNoC0:$rd, CSP:$rs1, uimm10_lsb0000:$imm),
-                  (C_CLCCSP_128 GPCRNoC0:$rd, CSP:$rs1, uimm10_lsb0000:$imm)>;
+def : CompressPat<(CLC_128 GPCRNoC0:$rd, CSPMem:$rs1, uimm10_lsb0000:$imm),
+                  (C_CLCCSP_128 GPCRNoC0:$rd, CSPMem:$rs1, uimm10_lsb0000:$imm)>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
-def : CompressPat<(CLW GPRNoX0:$rd, CSP:$rs1,  uimm8_lsb00:$imm),
-                  (C_CLWCSP GPRNoX0:$rd, CSP:$rs1, uimm8_lsb00:$imm)>;
+def : CompressPat<(CLW GPRNoX0:$rd, CSPMem:$rs1,  uimm8_lsb00:$imm),
+                  (C_CLWCSP GPRNoX0:$rd, CSPMem:$rs1, uimm8_lsb00:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
-def : CompressPat<(CLC_64 GPCRNoC0:$rd, CSP:$rs1, uimm9_lsb000:$imm),
-                  (C_CLCCSP_64 GPCRNoC0:$rd, CSP:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CLC_64 GPCRNoC0:$rd, CSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CLCCSP_64 GPCRNoC0:$rd, CSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CLD GPRNoX0:$rd, CSP:$rs1, uimm9_lsb000:$imm),
-                  (C_CLDCSP GPRNoX0:$rd, CSP:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CLD GPRNoX0:$rd, CSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CLDCSP GPRNoX0:$rd, CSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
@@ -2456,28 +2462,28 @@ def : CompressPat<(CJALR C1, GPCRNoC0:$rs1, 0),
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode] in {
-def : CompressPat<(CFSD FPR64:$rs2, CSP:$rs1, uimm9_lsb000:$imm),
-                  (C_CFSDCSP FPR64:$rs2, CSP:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CFSD FPR64:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CFSDCSP FPR64:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, HasStdExtD, IsRV32, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CSC_128 GPCR:$rs2, CSP:$rs1, uimm10_lsb0000:$imm),
-                  (C_CSCCSP_128 GPCR:$rs2, CSP:$rs1, uimm10_lsb0000:$imm)>;
+def : CompressPat<(CSC_128 GPCR:$rs2, CSPMem:$rs1, uimm10_lsb0000:$imm),
+                  (C_CSCCSP_128 GPCR:$rs2, CSPMem:$rs1, uimm10_lsb0000:$imm)>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode] in {
-def : CompressPat<(CSW GPR:$rs2, CSP:$rs1, uimm8_lsb00:$imm),
-                  (C_CSWCSP GPR:$rs2, CSP:$rs1, uimm8_lsb00:$imm)>;
+def : CompressPat<(CSW GPR:$rs2, CSPMem:$rs1, uimm8_lsb00:$imm),
+                  (C_CSWCSP GPR:$rs2, CSPMem:$rs1, uimm8_lsb00:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
-def : CompressPat<(CSC_64 GPCR:$rs2, CSP:$rs1, uimm9_lsb000:$imm),
-                  (C_CSCCSP_64 GPCR:$rs2, CSP:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CSC_64 GPCR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CSCCSP_64 GPCR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasCheri, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CSD GPR:$rs2, CSP:$rs1, uimm9_lsb000:$imm),
-                  (C_CSDCSP GPR:$rs2, CSP:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CSD GPR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CSDCSP GPR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecapOrCheri, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
@@ -293,13 +293,13 @@ let Predicates = [HasZCheriPurecap, IsCapMode] in {
 let DecoderNamespace = "ZCheriCapModeOnly_",
     hasSideEffects = 0, mayLoad = 1, mayStore = 0 in {
 def CLC : RVInstI<0b100, OPC_MISC_MEM, (outs GPCR:$rd),
-                  (ins GPCR:$rs1, simm12:$imm12),
+                  (ins GPCRMem:$rs1, simm12:$imm12),
                   "lc", "$rd, ${imm12}(${rs1})">;
 }
 def : InstAlias<"clc $rd, ${imm12}(${rs1})",
-                (CLC GPCR:$rd, GPCR:$rs1, simm12:$imm12), 0>;
+                (CLC GPCR:$rd, GPCRMem:$rs1, simm12:$imm12), 0>;
 defm : CPrefixedInstAlias<"lc $rd, (${rs1})",
-                          (CLC  GPCR:$rd, GPCR:$rs1, 0)>;
+                          (CLC  GPCR:$rd, GPCRMem:$rs1, 0)>;
 } // Predicates = [HasZCheriPurecap]
 
 // Store Capability
@@ -307,12 +307,12 @@ let Predicates = [HasZCheriPurecap, IsCapMode] in {
 let DecoderNamespace = "ZCheriCapModeOnly_", hasSideEffects = 0,
     mayLoad = 0, mayStore = 1 in
 def CSC : RVInstS<0b100, OPC_STORE, (outs),
-                       (ins GPCR:$rs2, GPCR:$rs1, simm12:$imm12),
+                       (ins GPCR:$rs2, GPCRMem:$rs1, simm12:$imm12),
                        "sc", "$rs2, ${imm12}(${rs1})">;
 def : InstAlias<"csc $rs2, ${imm12}(${rs1})",
-                (CSC  GPCR:$rs2, GPCR:$rs1, simm12:$imm12), 0>;
+                (CSC  GPCR:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
 defm : CPrefixedInstAlias<"sc $rs2, (${rs1})",
-                          (CSC  GPCR:$rs2, GPCR:$rs1, 0)>;
+                          (CSC  GPCR:$rs2, GPCRMem:$rs1, 0)>;
 } // Predicates = [HasZCheriPurecap]
 
 
@@ -452,23 +452,23 @@ def : CompressPat<(CADDI GPCRC:$rd, CSP:$rs1, uimm10_lsb00nonzero:$imm),
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsCapMode]
 
 let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CLC GPCRC:$rd, GPCRC:$rs1, uimm9_lsb0000:$imm),
-                  (C_CLC_128 GPCRC:$rd, GPCRC:$rs1, uimm9_lsb0000:$imm)>;
+def : CompressPat<(CLC GPCRC:$rd, GPCRCMem:$rs1, uimm9_lsb0000:$imm),
+                  (C_CLC_128 GPCRC:$rd, GPCRCMem:$rs1, uimm9_lsb0000:$imm)>;
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
-def : CompressPat<(CLC GPCRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm),
-                  (C_CLC_64 GPCRC:$rd, GPCRC:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CLC GPCRC:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CLC_64 GPCRC:$rd, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CSC GPCRC:$rs2, GPCRC:$rs1, uimm9_lsb0000:$imm),
-                  (C_CSC_128 GPCRC:$rs2, GPCRC:$rs1, uimm9_lsb0000:$imm)>;
+def : CompressPat<(CSC GPCRC:$rs2, GPCRCMem:$rs1, uimm9_lsb0000:$imm),
+                  (C_CSC_128 GPCRC:$rs2, GPCRCMem:$rs1, uimm9_lsb0000:$imm)>;
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
-def : CompressPat<(CSC GPCRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm),
-                  (C_CSC_64 GPCRC:$rs2, GPCRC:$rs1, uimm8_lsb000:$imm)>;
+def : CompressPat<(CSC GPCRC:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm),
+                  (C_CSC_64 GPCRC:$rs2, GPCRCMem:$rs1, uimm8_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 // Quadrant 1
@@ -479,23 +479,23 @@ def : CompressPat<(CADDI C2, C2, simm10_lsb0000nonzero:$imm),
 
 // Quadrant 2
 let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CLC GPCRNoC0:$rd, CSP:$rs1, uimm10_lsb0000:$imm),
-                  (C_CLCCSP_128 GPCRNoC0:$rd, CSP:$rs1, uimm10_lsb0000:$imm)>;
+def : CompressPat<(CLC GPCRNoC0:$rd, CSPMem:$rs1, uimm10_lsb0000:$imm),
+                  (C_CLCCSP_128 GPCRNoC0:$rd, CSPMem:$rs1, uimm10_lsb0000:$imm)>;
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
-def : CompressPat<(CLC GPCRNoC0:$rd, CSP:$rs1, uimm9_lsb000:$imm),
-                  (C_CLCCSP_64 GPCRNoC0:$rd, CSP:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CLC GPCRNoC0:$rd, CSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CLCCSP_64 GPCRNoC0:$rd, CSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
-def : CompressPat<(CSC GPCR:$rs2, CSP:$rs1, uimm10_lsb0000:$imm),
-                  (C_CSCCSP_128 GPCR:$rs2, CSP:$rs1, uimm10_lsb0000:$imm)>;
+def : CompressPat<(CSC GPCR:$rs2, CSPMem:$rs1, uimm10_lsb0000:$imm),
+                  (C_CSCCSP_128 GPCR:$rs2, CSPMem:$rs1, uimm10_lsb0000:$imm)>;
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
 
 let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
-def : CompressPat<(CSC GPCR:$rs2, CSP:$rs1, uimm9_lsb000:$imm),
-                  (C_CSCCSP_64 GPCR:$rs2, CSP:$rs1, uimm9_lsb000:$imm)>;
+def : CompressPat<(CSC GPCR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm),
+                  (C_CSCCSP_64 GPCR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm)>;
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 //===----------------------------------------------------------------------===//
@@ -593,7 +593,7 @@ let Predicates = [HasStdExtZicbop, IsCapMode] in {
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CCLoadB_ri<bits<6> funct6, string OpcodeStr>
     : RVInst16CLB<funct6, 0b00, (outs GPRC:$rd),
-                  (ins GPCRC:$rs1, uimm2:$imm),
+                  (ins GPCRCMem:$rs1, uimm2:$imm),
                   OpcodeStr, "$rd, ${imm}(${rs1})"> {
   bits<2> imm;
 
@@ -651,8 +651,8 @@ def C_CSH : CCStoreH_rri<0b100011, 0b0, "c.sh">,
 // Patterns
 
 let Predicates = [HasStdExtZcb, HasZCheriPurecap, IsCapMode] in {
-def : CompressPat<(CLBU GPRC:$rd, GPCRC:$rs1, uimm2:$imm),
-                  (C_CLBU GPRC:$rd, GPCRC:$rs1, uimm2:$imm)>;
+def : CompressPat<(CLBU GPRC:$rd, GPCRCMem:$rs1, uimm2:$imm),
+                  (C_CLBU GPRC:$rd, GPCRCMem:$rs1, uimm2:$imm)>;
 def : CompressPat<(LHU GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm),
                   (C_LHU GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
 def : CompressPat<(LH GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm),

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
@@ -49,21 +49,28 @@ class ZCheri_rr<bits<7> funct7, bits<3> funct3, string opcodestr,
 let Predicates = [HasZCheriPurecap] in {
 def GCTAG  : ZCheri_r<0x0, "gctag" >,
                  Sched<[WriteCHERIInspect, ReadCHERIInspect]>;
+def : InstAlias<"ytagr $rd, $rs1", (GCTAG GPR:$rd, YGPR:$rs1), 0>;
 def GCPERM : ZCheri_r<0x1, "gcperm">,
                  Sched<[WriteCHERIInspect, ReadCHERIInspect]>;
+def : InstAlias<"ypermr $rd, $rs1", (GCPERM GPR:$rd, YGPR:$rs1), 0>;
 def GCHI   : ZCheri_r<0x4, "gchi"  >,
                  Sched<[WriteCHERIInspect, ReadCHERIInspect]>;
+def : InstAlias<"yhir $rd, $rs1", (GCHI GPR:$rd, YGPR:$rs1), 0>;
 def GCBASE : ZCheri_r<0x5, "gcbase">,
                  Sched<[WriteCHERIInspect, ReadCHERIInspect]>;
+def : InstAlias<"ybaser $rd, $rs1", (GCBASE GPR:$rd, YGPR:$rs1), 0>;
 def GCLEN  : ZCheri_r<0x6, "gclen" >,
                  Sched<[WriteCHERIInspect, ReadCHERIInspect]>;
+def : InstAlias<"ylenr $rd, $rs1", (GCLEN GPR:$rd, YGPR:$rs1), 0>;
 def GCTYPE : ZCheri_r<0x2, "gctype">,
                  Sched<[WriteCHERIInspect, ReadCHERIInspect]>;
+def : InstAlias<"ytyper $rd, $rs1", (GCTYPE GPR:$rd, YGPR:$rs1), 0>;
 } // Predicates = [HasZCheriPurecap]
 
 let Predicates = [HasZCheriHybrid] in {
 def GCMODE : ZCheri_r<0x3, "gcmode">,
                  Sched<[WriteCHERIInspect, ReadCHERIInspect]>;
+def : InstAlias<"ymoder $rd, $rs1", (GCMODE GPR:$rd, YGPR:$rs1), 0>;
 } // Predicates = [HasZCheriHybrid]
 
 //===----------------------------------------------------------------------===//
@@ -73,27 +80,41 @@ def GCMODE : ZCheri_r<0x3, "gcmode">,
 let Predicates = [HasZCheriPurecap] in {
 def SCADDR        : ZCheri_rr<0x6, 0x1, "scaddr">,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
+def : InstAlias<"yaddrw $rd, $rs1, $rs2", (SCADDR YGPR:$rd, YGPR:$rs1, GPR:$rs2), 0>;
 def ACPERM        : ZCheri_rr<0x6, 0x2, "acperm">,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
 def SCHI          : ZCheri_rr<0x6, 0x3, "schi">,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
+def : InstAlias<"yhiw $rd, $rs1, $rs2", (SCHI YGPR:$rd, YGPR:$rs1, GPR:$rs2), 0>;
 let isReMaterializable = 1, isAsCheapAsAMove = 1 in {
 def CADD          : CheriRVInstR<0x6, 0x0, OPC_OP, "cadd", GPCR, GPCR, GPRNoX0>,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
 def CADDI         : CheriRVInstrI<0x2, OPC_OP_IMM_32, "caddi", 1>,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
 }
+def : InstAlias<"add $cd, $cs1, $rs2",
+                (CADD GPCR:$cd, GPCR:$cs1, GPRNoX0:$rs2), 0>;
+def : InstAlias<"yadd $cd, $cs1, $rs2", (CADD YGPR:$cd, YGPR:$cs1, GPRNoX0:$rs2), 0>;
+def : InstAlias<"add $cd, $cs1, $imm",
+                (CADDI GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
+def : InstAlias<"yaddi $cd, $cs1, $imm", (CADDI YGPR:$cd, YGPR:$cs1, simm12:$imm), 0>;
+def : InstAlias<"yadd $cd, $cs1, $imm", (CADDI YGPR:$cd, YGPR:$cs1, simm12:$imm), 0>;
+
 let defsCanBeSealed = 1 in {
 def SENTRY        : ZCheri_r<0x8, "sentry", GPCR>,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
 def CBLD          : ZCheri_rr<0x6, 0x5, "cbld", GPCR, GPCRNoC0, GPCR>,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
 } // defsCanBeSealed = 1
+def : InstAlias<"ysentry $rd, $rs1", (SENTRY YGPR:$rd, YGPR:$rs1), 0>;
+def : InstAlias<"ybld $cd, $cs1, $cs2", (CBLD YGPR:$cd, YGPRNoX0:$cs1, YGPR:$cs2), 0>;
 
 def SCBNDS        : ZCheri_rr<0x7, 0x0, "scbnds">,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
+def : InstAlias<"ybndsw $cd, $cs1, $rs2", (SCBNDS YGPR:$cd, YGPR:$cs1, GPR:$rs2), 0>;
 def SCBNDSR       : ZCheri_rr<0x7, 0x1, "scbndsr">,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
+def : InstAlias<"ybndsrw $rd, $rs1, $rs2", (SCBNDSR YGPR:$rd, YGPR:$rs1, GPR:$rs2), 0>;
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 def SCBNDSI
     : RVInstCheriSetBoundsImmFmt<0x1, 0x5, OPC_OP_IMM, (outs GPCR:$rd),
@@ -104,15 +125,14 @@ def SCBNDSI
 
 def : InstAlias<"scbnds $cd, $cs1, $imm",
                 (SCBNDSI GPCR:$cd, GPCR:$cs1, csetbnd_imm:$imm), 0>;
-def : InstAlias<"add $cd, $cs1, $imm",
-                (CADDI GPCR:$cd, GPCR:$cs1, simm12:$imm), 0>;
-def : InstAlias<"add $cd, $cs1, $rs2",
-                (CADD GPCR:$cd, GPCR:$cs1, GPRNoX0:$rs2), 0>;
+def : InstAlias<"ybndsw $cd, $cs1, $imm", (SCBNDSI YGPR:$cd, YGPR:$cs1, csetbnd_imm:$imm), 0>;
+def : InstAlias<"ybndswi $rd, $rs1, $imm", (SCBNDSI YGPR:$rd, YGPR:$rs1, csetbnd_imm:$imm), 0>;
 } // HasZCheriPurecap
 
 let Predicates = [HasZCheriHybrid] in {
 def SCMODE        : ZCheri_rr<0x6, 0x7, "scmode">,
                         Sched<[WriteCHERIMod, ReadCHERIMod]>;
+def : InstAlias<"ymodew $rd, $rs1, $rs2", (SCMODE YGPR:$rd, YGPR:$rs1, GPR:$rs2), 0>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -135,6 +155,7 @@ def CMV       : Cheri_SrcDst<0x6, 0x0, 0x0, OPC_OP, "cmv", GPCR>,
                     Sched<[WriteCHERIMove, ReadCHERIMove]>;
 def : InstAlias<"mv $cd, $cs1",
                 (CMV GPCR:$cd, GPCR:$cs1), 0>;
+def : InstAlias<"ymv $cd, $cs1", (CMV YGPR:$cd, YGPR:$cs1), 0>;
 } // HasZCheriPurecap
 
 
@@ -145,7 +166,7 @@ def : InstAlias<"mv $cd, $cs1",
 let Predicates = [HasZCheriPurecap] in {
 def CRAM_ : ZCheri_r<0x7, "cram", GPR, GPR>,
                 Sched<[WriteCHERIComputeMask, ReadCHERIComputeMask]>;
-
+def : InstAlias<"yamask $rd, $rs1", (CRAM_ GPR:$rd, GPR:$rs1), 0>;
 } // HasZCheriPurecap
 
 //===----------------------------------------------------------------------===//
@@ -155,8 +176,10 @@ def CRAM_ : ZCheri_r<0x7, "cram", GPR, GPR>,
 let Predicates = [HasZCheriPurecap] in {
 def SCSS : ZCheri_rr<0x6, 0x6, "scss", GPR, GPCRNoC0, GPCR>,
                Sched<[WriteCHERITest, ReadCHERITest]>;
+def : InstAlias<"yss $rd, $cs1, $cs2", (SCSS GPR:$rd, YGPRNoX0:$cs1, YGPR:$cs2), 0>;
 def SCEQ : ZCheri_rr<0x6, 0x4, "sceq", GPR, GPCR, GPCR>,
                Sched<[WriteCHERITest, ReadCHERITest]>;
+def : InstAlias<"yeq $rd, $cs1, $cs2", (SCEQ GPR:$rd, YGPR:$cs1, YGPR:$cs2), 0>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -255,12 +278,16 @@ def LC  : RVInstI<0b100, OPC_MISC_MEM, (outs GPCR:$rd),
                       (ins GPR:$rs1, simm12:$imm12),
                       "lc", "$rd, ${imm12}(${rs1})">,
               Sched<[WriteCHERILoadCap, ReadCHERILoadCap]>;
+def : InstAlias<"ly $rd, ${imm12}(${rs1})", (LC YGPR:$rd, GPR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"ly $rd, (${rs1})", (LC YGPR:$rd, GPR:$rs1, 0), 0>;
 
 let DecoderNamespace = "ZCheriOnly_", hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def SC  : RVInstS<0b100, OPC_STORE, (outs),
                       (ins GPCR:$rs2, GPR:$rs1, simm12:$imm12),
                       "sc", "$rs2, ${imm12}(${rs1})">,
               Sched<[WriteCHERIStoreCap, ReadCHERIStoreCap]>;
+def : InstAlias<"sy $rs2, ${imm12}(${rs1})", (SC YGPR:$rs2, GPR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"sy $rs2, (${rs1})", (SC YGPR:$rs2, GPR:$rs1, 0), 0>;
 
 let EmitPriority = 0 in {
 def : InstAlias<"lc $rd, (${rs1})",
@@ -274,10 +301,22 @@ let Predicates = [HasZCheriPurecap, HasStdExtA, NotCapMode] in {
 let DecoderNamespace = "ZCheriOnly_" in {
   defm LR_C      : LR_C_r_aq_rl<"", 0b100, "lr.c">,
                        Sched<[WriteCHERIAtomicLDC, ReadCHERIAtomicLDC]>;
+}
+defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "LR_C", "",
+                         (? YGPR:$rd, GPRMemZeroOffset:$rs1)>;
+
+let DecoderNamespace = "ZCheriOnly_" in {
   defm SC_C      : AMO_C_rr_aq_rl<"", 0b00011, 0b100, "sc.c", GPR>;
+}
+defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "SC_C", "",
+                         (? GPR:$rd, GPRMemZeroOffset:$rs1, YGPR:$rs2)>;
+
+let DecoderNamespace = "ZCheriOnly_" in {
   defm AMOSWAP_C : AMO_C_rr_aq_rl<"", 0b00001, 0b100, "amoswap.c", GPCR>,
                        Sched<[WriteCHERIAtomicC, ReadCHERIAtomicC]>;
 }
+defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "AMOSWAP_C", "",
+                         (? YGPR:$rd, GPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -299,6 +338,10 @@ def : InstAlias<"clc $rd, ${imm12}(${rs1})",
                 (CLC GPCR:$rd, GPCRMem:$rs1, simm12:$imm12), 0>;
 defm : CPrefixedInstAlias<"lc $rd, (${rs1})",
                           (CLC  GPCR:$rd, GPCRMem:$rs1, 0)>;
+def : InstAlias<"ly $rd, ${imm12}(${rs1})",
+                (CLC YGPR:$rd, YGPR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"ly $rd, (${rs1})",
+                (CLC YGPR:$rd, YGPR:$rs1, 0), 0>;
 } // Predicates = [HasZCheriPurecap]
 
 // Store Capability
@@ -312,6 +355,10 @@ def : InstAlias<"csc $rs2, ${imm12}(${rs1})",
                 (CSC  GPCR:$rs2, GPCRMem:$rs1, simm12:$imm12), 0>;
 defm : CPrefixedInstAlias<"sc $rs2, (${rs1})",
                           (CSC  GPCR:$rs2, GPCRMem:$rs1, 0)>;
+def : InstAlias<"sy $rs2, ${imm12}(${rs1})",
+                (CSC  YGPR:$rs2, YGPR:$rs1, simm12:$imm12), 0>;
+def : InstAlias<"sy $rs2, (${rs1})",
+                (CSC  YGPR:$rs2, YGPR:$rs1, 0), 0>;
 } // Predicates = [HasZCheriPurecap]
 
 
@@ -319,8 +366,16 @@ defm : CPrefixedInstAlias<"sc $rs2, (${rs1})",
 
 let Predicates = [HasZCheriPurecap, HasStdExtA, IsCapMode] in {
 defm CLR_C       : CLR_C_r_aq_rl<"", 0b100, "lr.c", "ZCheriCapModeOnly_">;
+defm : AtomicInstAliases<"lr.y", " $rd, $rs1", "CLR_C", "",
+                         (? YGPR:$rd, YGPRMemZeroOffset:$rs1)>;
+
 defm CSC_C       : CAMO_C_rr_aq_rl<"", 0b00011, 0b100, "sc.c", GPR, "ZCheriCapModeOnly_">;
+defm : AtomicInstAliases<"sc.y", " $rd, $rs2, $rs1", "CSC_C", "",
+                         (? GPR:$rd, YGPRMemZeroOffset:$rs1, YGPR:$rs2)>;
+
 defm CAMOSWAP_C  : CAMO_C_rr_aq_rl<"", 0b00001, 0b100, "amoswap.c", GPCR, "ZCheriCapModeOnly_">;
+defm : AtomicInstAliases<"amoswap.y", " $rd, $rs2, $rs1", "CAMOSWAP_C", "",
+                         (? YGPR:$rd, YGPRMemZeroOffset:$rs1, YGPR:$rs2)>;
 }
 
 
@@ -495,6 +550,20 @@ def : CompressPat<(CSC GPCR:$rs2, CSPMem:$rs1, uimm10_lsb0000:$imm),
 let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
 def : CompressPat<(CSC GPCR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm),
                   (C_CSCCSP_64 GPCR:$rs2, CSPMem:$rs1, uimm9_lsb000:$imm)>;
+} // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
+
+let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode] in {
+def : InstAlias<"c.sy $rs2, ${imm}(${rs1})", (C_CSC_128 YGPRC:$rs2, YGPRC:$rs1, uimm9_lsb0000:$imm), 0>;
+def : InstAlias<"c.sysp $rs2, ${imm}(${rs1})", (C_CSCCSP_128 YGPRNoX0:$rs2, YSP:$rs1, uimm10_lsb0000:$imm), 0>;
+def : InstAlias<"c.ly $rd, ${imm}(${rs1})", (C_CLC_128 YGPRC:$rd, YGPRC:$rs1, uimm9_lsb0000:$imm), 0>;
+def : InstAlias<"c.lysp $rd, ${imm}(${rs1})", (C_CLCCSP_128 YGPRNoX0:$rd, YSP:$rs1, uimm10_lsb0000:$imm), 0>;
+} // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV64, IsCapMode]
+
+let Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode] in {
+def : InstAlias<"c.sy $rs2, ${imm}(${rs1})", (C_CSC_64 YGPRC:$rs2, YGPRC:$rs1, uimm8_lsb000:$imm), 0>;
+def : InstAlias<"c.sysp $rs2, ${imm}(${rs1})", (C_CSCCSP_64 YGPRNoX0:$rs2, YSP:$rs1, uimm9_lsb000:$imm), 0>;
+def : InstAlias<"c.ly $rd, ${imm}(${rs1})", (C_CLC_64 YGPRC:$rd, YGPRC:$rs1, uimm8_lsb000:$imm), 0>;
+def : InstAlias<"c.lysp $rd, ${imm}(${rs1})", (C_CLCCSP_64 YGPRNoX0:$rd, YSP:$rs1, uimm9_lsb000:$imm), 0>;
 } // Predicates = [HasZCheriPurecap, HasCheriRVC, HasStdExtC, IsRV32, IsCapMode]
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
@@ -181,10 +181,9 @@ let isCall = 1, hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
 } // isCall, hasSideEffects, mayLoad, mayStore
 
 let Predicates = [IsCapMode, HasZCheriPurecap] in {
-  def : InstAlias<"jalr $rd, ${imm12}(${rs1})", (JALR_MODE_CAP GPR:$rd, GPR:$rs1, immzero:$imm12), 2>;
-  def : InstAlias<"jalr $rd, $rs1"            , (JALR_MODE_CAP GPR:$rd, GPR:$rs1, 0             ), 2>;
-  def : InstAlias<"jalr $rs1"                 , (JALR_MODE_CAP X1     , GPR:$rs1, 0             ), 2>;
-  def : InstAlias<"jr $rs1"                   , (JALR_MODE_CAP X0     , GPR:$rs1, 0             ), 2>;
+  def : InstAlias<"jalr.mode $rd, $rs1"            , (JALR_MODE_CAP GPR:$rd, GPR:$rs1, 0             ), 2>;
+  def : InstAlias<"jalr.mode $rs1"                 , (JALR_MODE_CAP X1     , GPR:$rs1, 0             ), 2>;
+  def : InstAlias<"jr.mode $rs1"                   , (JALR_MODE_CAP X0     , GPR:$rs1, 0             ), 2>;
   def : InstAlias<"ret.mode"                  , (JALR_MODE_CAP X0     , X1      , 0             ), 2>;
 } // Predicates = [IsCapMode, HasZCheriPurecap]
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZCheriPurecap.td
@@ -602,7 +602,7 @@ class CCLoadB_ri<bits<6> funct6, string OpcodeStr>
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CCStoreB_rri<bits<6> funct6, string OpcodeStr>
     : RVInst16CSB<funct6, 0b00, (outs),
-                  (ins GPRC:$rs2, GPCRC:$rs1, uimm2:$imm),
+                  (ins GPRC:$rs2, GPCRCMem:$rs1, uimm2:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})"> {
   bits<2> imm;
 
@@ -612,7 +612,7 @@ class CCStoreB_rri<bits<6> funct6, string OpcodeStr>
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CCLoadH_ri<bits<6> funct6, bit funct1, string OpcodeStr>
     : RVInst16CLH<funct6, funct1, 0b00, (outs GPRC:$rd),
-                  (ins GPCRC:$rs1, uimm2_lsb0:$imm),
+                  (ins GPCRCMem:$rs1, uimm2_lsb0:$imm),
                   OpcodeStr, "$rd, ${imm}(${rs1})"> {
   bits<2> imm;
 
@@ -622,7 +622,7 @@ class CCLoadH_ri<bits<6> funct6, bit funct1, string OpcodeStr>
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CCStoreH_rri<bits<6> funct6, bit funct1, string OpcodeStr>
     : RVInst16CSH<funct6, funct1, 0b00, (outs),
-                  (ins GPRC:$rs2, GPCRC:$rs1, uimm2_lsb0:$imm),
+                  (ins GPRC:$rs2, GPCRCMem:$rs1, uimm2_lsb0:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})"> {
   bits<2> imm;
 
@@ -652,14 +652,14 @@ def C_CSH : CCStoreH_rri<0b100011, 0b0, "c.sh">,
 let Predicates = [HasStdExtZcb, HasZCheriPurecap, IsCapMode] in {
 def : CompressPat<(CLBU GPRC:$rd, GPCRCMem:$rs1, uimm2:$imm),
                   (C_CLBU GPRC:$rd, GPCRCMem:$rs1, uimm2:$imm)>;
-def : CompressPat<(LHU GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_LHU GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
-def : CompressPat<(LH GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_LH GPRC:$rd, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
-def : CompressPat<(SB GPRC:$rs2, GPRCMem:$rs1, uimm2:$imm),
-                  (C_SB GPRC:$rs2, GPRCMem:$rs1, uimm2:$imm)>;
-def : CompressPat<(SH GPRC:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm),
-                  (C_SH GPRC:$rs2, GPRCMem:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(CLHU GPRC:$rd, GPCRCMem:$rs1, uimm2_lsb0:$imm),
+                  (C_CLHU GPRC:$rd, GPCRCMem:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(CLH GPRC:$rd, GPCRCMem:$rs1, uimm2_lsb0:$imm),
+                  (C_CLH GPRC:$rd, GPCRCMem:$rs1, uimm2_lsb0:$imm)>;
+def : CompressPat<(CSB GPRC:$rs2, GPCRCMem:$rs1, uimm2:$imm),
+                  (C_CSB GPRC:$rs2, GPCRCMem:$rs1, uimm2:$imm)>;
+def : CompressPat<(CSH GPRC:$rs2, GPCRCMem:$rs1, uimm2_lsb0:$imm),
+                  (C_CSH GPRC:$rs2, GPCRCMem:$rs1, uimm2_lsb0:$imm)>;
 } // Predicates = [HasStdExtZcb, HasZCheriPurecap, IsCapMode]
 
 // Pseudo Instructions

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -346,6 +346,42 @@ def GPCRNoC0 : RegisterClass<"RISCV", [CLenVT], 64, (sub GPCR, C0)> {
   let RegInfos = CLenRI;
 }
 
+def YGPROperand : AsmOperandClass {
+  let Name = "YGPR";
+  let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidYGPR";
+}
+def YGPR : RegisterOperand<GPCR> {
+  let ParserMatchClass = YGPROperand;
+}
+
+def YGPRNoX0Operand : AsmOperandClass {
+  let Name = "YGPRNoX0";
+  let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidYGPRNoX0";
+}
+def YGPRNoX0 : RegisterOperand<GPCRNoC0> {
+  let ParserMatchClass = YGPRNoX0Operand;
+}
+
+def RVYCompatGPCROperand : AsmOperandClass {
+  let Name = "RVYCompatGPCR";
+  let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidRVYCompatGPCR";
+}
+def RVYCompatGPCR : RegisterOperand<GPCR> {
+  let ParserMatchClass = RVYCompatGPCROperand;
+}
+
+def RVYCompatGPCRNoC0Operand : AsmOperandClass {
+  let Name = "RVYCompatGPCRNoC0";
+  let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidRVYCompatGPCRNoC0";
+}
+def RVYCompatGPCRNoC0 : RegisterOperand<GPCRNoC0> {
+  let ParserMatchClass = RVYCompatGPCRNoC0Operand;
+}
+
 def GPRNoX0X2 : GPRRegisterClass<(sub GPR, X0, X2)>;
 
 def GPRX7 : GPRRegisterClass<(add X7)>;
@@ -385,10 +421,55 @@ def GPCRTC : RegisterClass<"RISCV", [CLenVT], 64, (add
   let RegInfos = CLenRI;
 }
 
+def YGPRCOperand : AsmOperandClass {
+  let Name = "YGPRC";
+  let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidYGPRC";
+}
+def YGPRC : RegisterOperand<GPCRC> {
+  let ParserMatchClass = YGPRCOperand;
+}
+
+def RVYCompatGPCRCOperand : AsmOperandClass {
+  let Name = "RVYCompatGPCRC";
+  let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidRVYCompatGPCR";
+}
+def RVYCompatGPCRC : RegisterOperand<GPCRC> {
+  let ParserMatchClass = RVYCompatGPCRCOperand;
+}
+
+def RVYCompatGPCRTCOperand : AsmOperandClass {
+  let Name = "RVYCompatGPCRTC";
+  let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidRVYCompatGPCR";
+}
+def RVYCompatGPCRTC : RegisterOperand<GPCRTC> {
+  let ParserMatchClass = RVYCompatGPCRTCOperand;
+}
+
 def SP : GPRRegisterClass<(add X2)>;
 
 def CSP : RegisterClass<"RISCV", [CLenVT], 64, (add C2)> {
   let RegInfos = CLenRI;
+}
+
+def YSPOperand : AsmOperandClass {
+  let Name = "YSP";
+  let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidYSP";
+}
+def YSP : RegisterOperand<CSP> {
+  let ParserMatchClass = YSPOperand;
+}
+
+def RVYCompatCSPOperand : AsmOperandClass {
+  let Name = "RVYCompatCSP";
+  let RenderMethod = "addRegOperands";
+  let DiagnosticType = "InvalidRVYCompatCSP";
+}
+def RVYCompatCSP : RegisterOperand<CSP> {
+  let ParserMatchClass = RVYCompatCSPOperand;
 }
 
 // Saved Registers from s0 to s7, for C.MVA01S07 instruction in Zcmp extension

--- a/llvm/test/MC/RISCV/cheri/bakewell/rv32zcheripurecap.s
+++ b/llvm/test/MC/RISCV/cheri/bakewell/rv32zcheripurecap.s
@@ -12,20 +12,20 @@ gchi a0, ca0
 # CHECK-ASM: encoding: [0x33,0x35,0xa5,0x0c]
 schi ca0, ca0, a0
 
-# CHECK-ASM-AND-OBJ: jalr.mode a0, 0(a0)
-# CHECK-ASM: encoding: [0x67,0x15,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr ca0, 0(ca0)
+# CHECK-ASM: encoding: [0x67,0x05,0x05,0x00]
 jalr a0, 0(a0)
 
-# CHECK-ASM-AND-OBJ: jalr.mode a0, 0(a0)
-# CHECK-ASM: encoding: [0x67,0x15,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr ca0, 0(ca0)
+# CHECK-ASM: encoding: [0x67,0x05,0x05,0x00]
 jalr a0, a0
 
-# CHECK-ASM-AND-OBJ: jalr.mode ra, 0(a0)
-# CHECK-ASM: encoding: [0xe7,0x10,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr cra, 0(ca0)
+# CHECK-ASM: encoding: [0xe7,0x00,0x05,0x00]
 jalr a0
 
-# CHECK-ASM-AND-OBJ: jalr.mode zero, 0(a0)
-# CHECK-ASM: encoding: [0x67,0x10,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr cnull, 0(ca0)
+# CHECK-ASM: encoding: [0x67,0x00,0x05,0x00]
 jr a0
 
 # CHECK-ASM-AND-OBJ: jalr.mode zero, 0(ra)

--- a/llvm/test/MC/RISCV/cheri/bakewell/rv64zcheripurecap.s
+++ b/llvm/test/MC/RISCV/cheri/bakewell/rv64zcheripurecap.s
@@ -12,20 +12,20 @@ gchi a0, ca0
 # CHECK-ASM: encoding: [0x33,0x35,0xa5,0x0c]
 schi ca0, ca0, a0
 
-# CHECK-ASM-AND-OBJ: jalr.mode a0, 0(a0)
-# CHECK-ASM: encoding: [0x67,0x15,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr ca0, 0(ca0)
+# CHECK-ASM: encoding: [0x67,0x05,0x05,0x00]
 jalr a0, 0(a0)
 
-# CHECK-ASM-AND-OBJ: jalr.mode a0, 0(a0)
-# CHECK-ASM: encoding: [0x67,0x15,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr ca0, 0(ca0)
+# CHECK-ASM: encoding: [0x67,0x05,0x05,0x00]
 jalr a0, a0
 
-# CHECK-ASM-AND-OBJ: jalr.mode ra, 0(a0)
-# CHECK-ASM: encoding: [0xe7,0x10,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr cra, 0(ca0)
+# CHECK-ASM: encoding: [0xe7,0x00,0x05,0x00]
 jalr a0
 
-# CHECK-ASM-AND-OBJ: jalr.mode zero, 0(a0)
-# CHECK-ASM: encoding: [0x67,0x10,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr cnull, 0(ca0)
+# CHECK-ASM: encoding: [0x67,0x00,0x05,0x00]
 jr a0
 
 # CHECK-ASM-AND-OBJ: jalr.mode zero, 0(ra)

--- a/llvm/test/MC/RISCV/cheri/bakewell/rvy-mnemonic-compat-both-modes.s
+++ b/llvm/test/MC/RISCV/cheri/bakewell/rvy-mnemonic-compat-both-modes.s
@@ -1,0 +1,65 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+zcheripurecap,+zcherihybrid -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck --check-prefixes=CHECK %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+zcheripurecap,+zcherihybrid -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck --check-prefixes=CHECK %s
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+zcheripurecap,+zcherihybrid,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck --check-prefixes=CHECK %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+zcheripurecap,+zcherihybrid,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck --check-prefixes=CHECK %s
+
+# CHECK: gcperm ra, csp # encoding: [0xb3,0x00,0x11,0x10]
+ypermr x1, x2
+# CHECK-NEXT: gctype ra, csp # encoding: [0xb3,0x00,0x21,0x10]
+ytyper x1, x2
+# CHECK-NEXT: gcbase ra, csp # encoding: [0xb3,0x00,0x51,0x10]
+ybaser x1, x2
+# CHECK-NEXT: gclen ra, csp # encoding: [0xb3,0x00,0x61,0x10]
+ylenr x1, x2
+# CHECK-NEXT: gctag ra, csp # encoding: [0xb3,0x00,0x01,0x10]
+ytagr x1, x2
+# CHECK-NEXT: gchi ra, csp # encoding: [0xb3,0x00,0x41,0x10]
+yhir x1, x2
+# CHECK-NEXT: scaddr cra, csp, gp # encoding: [0xb3,0x10,0x31,0x0c]
+yaddrw x1, x2, x3
+# CHECK-NEXT: schi cra, csp, gp # encoding: [0xb3,0x30,0x31,0x0c]
+yhiw x1, x2, x3
+# CHECK-NEXT: cadd cra, csp, gp # encoding: [0xb3,0x00,0x31,0x0c]
+yadd x1, x2, x3
+# CHECK-NEXT: caddi cra, csp, -173 # encoding: [0x9b,0x20,0x31,0xf5]
+yaddi x1, x2, -173
+# CHECK-NEXT: caddi cra, csp, -173 # encoding: [0x9b,0x20,0x31,0xf5]
+yadd x1, x2, -173
+# CHECK-NEXT: sentry cra, csp # encoding: [0xb3,0x00,0x81,0x10]
+ysentry x1, x2
+# CHECK-NEXT: cbld cra, csp, cgp # encoding: [0xb3,0x50,0x31,0x0c]
+ybld x1, x2, x3
+# CHECK-NEXT: scbndsr cra, csp, gp # encoding: [0xb3,0x10,0x31,0x0e]
+ybndsrw x1, x2, x3
+# CHECK-NEXT: scbnds cra, csp, gp # encoding: [0xb3,0x00,0x31,0x0e]
+ybndsw x1, x2, x3
+# CHECK-NEXT: scbndsi cra, csp, 496 # encoding: [0x93,0x50,0xf1,0x07]
+ybndsw x1, x2, 496
+# CHECK-NEXT: scbndsi cra, csp, 496 # encoding: [0x93,0x50,0xf1,0x07]
+ybndswi x1, x2, 496
+# CHECK-NEXT: cmv cra, csp # encoding: [0xb3,0x00,0x01,0x0c]
+ymv x1, x2
+# CHECK-NEXT: cram ra, sp # encoding: [0xb3,0x00,0x71,0x10]
+yamask x1, x2
+# CHECK-NEXT: scss ra, csp, cgp # encoding: [0xb3,0x60,0x31,0x0c]
+yss x1, x2, x3
+# CHECK-NEXT: sceq ra, csp, cgp # encoding: [0xb3,0x40,0x31,0x0c]
+yeq x1, x2, x3
+# CHECK-NEXT: gcmode ra, csp # encoding: [0xb3,0x00,0x31,0x10]
+ymoder x1, x2
+# CHECK-NEXT: scmode cra, csp, gp # encoding: [0xb3,0x70,0x31,0x0c]
+ymodew x1, x2, x3
+
+## Check that ABI register names work as expected
+# CHECK: gcperm ra, csp # encoding: [0xb3,0x00,0x11,0x10]
+ypermr ra, sp
+# CHECK-NEXT: caddi cra, csp, -173 # encoding: [0x9b,0x20,0x31,0xf5]
+yaddi ra, sp, -173
+# CHECK-NEXT: sentry cra, csp # encoding: [0xb3,0x00,0x81,0x10]
+ysentry ra, sp
+# CHECK-NEXT: cbld cra, csp, cgp # encoding: [0xb3,0x50,0x31,0x0c]
+ybld ra, sp, gp

--- a/llvm/test/MC/RISCV/cheri/bakewell/rvy-mnemonic-compat-capmode.s
+++ b/llvm/test/MC/RISCV/cheri/bakewell/rvy-mnemonic-compat-capmode.s
@@ -1,0 +1,55 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+f,+d,+zcheripurecap,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+f,+d,+zcheripurecap,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck %s
+
+## Check that RVY mnemonics are accepted and we can use X register names
+# CHECK:      lc cra, 0(csp) # encoding: [0x8f,0x40,0x01,0x00]
+ly x1, 0(x2)
+# CHECK-NEXT: sc cra, 0(csp) # encoding: [0x23,0x40,0x11,0x00]
+sy x1, 0(x2)
+# CHECK-NEXT: lr.c cra, (csp) # encoding: [0xaf,0x40,0x01,0x10]
+lr.y x1, (x2)
+# CHECK-NEXT: lr.c.aq cra, (csp) # encoding: [0xaf,0x40,0x01,0x14]
+lr.y.aq x1, (x2)
+# CHECK-NEXT: sc.c gp, cgp, (csp) # encoding: [0xaf,0x41,0x31,0x18]
+sc.y x3, x3, (x2)
+# CHECK-NEXT: amoswap.c cra, cgp, (csp) # encoding: [0xaf,0x40,0x31,0x08]
+amoswap.y x1, x3, (x2)
+
+## In capability mode, standard integer memory access instructions (lb/lw) use capability
+## base registers. We test here that unprefixed integer register names (x2) are correctly
+## coerced to capability base registers (csp) by the parser, even though these are not new instructions.
+# CHECK:      lb ra, 0(csp) # encoding: [0x83,0x00,0x01,0x00]
+lb x1, 0(x2)
+# CHECK-NEXT: lw ra, 0(csp) # encoding: [0x83,0x20,0x01,0x00]
+lw x1, 0(x2)
+# CHECK-NEXT: amoadd.w ra, gp, (csp) # encoding: [0xaf,0x20,0x31,0x00]
+amoadd.w x1, x3, (x2)
+# CHECK-NEXT: flw ft1, 0(csp) # encoding: [0x87,0x20,0x01,0x00]
+flw ft1, 0(x2)
+# CHECK-NEXT: fld fa0, 0(csp) # encoding: [0x07,0x35,0x01,0x00]
+fld fa0, 0(x2)
+# CHECK-NEXT: fsw ft1, 0(csp) # encoding: [0x27,0x20,0x11,0x00]
+fsw ft1, 0(x2)
+# CHECK-NEXT: fsd fa0, 0(csp) # encoding: [0x27,0x30,0xa1,0x00]
+fsd fa0, 0(x2)
+
+## Same for jump instructions
+# CHECK:      jalr cnull, 0(cra) # encoding: [0x67,0x80,0x00,0x00]
+jr x1
+# CHECK-NEXT: jalr cra, 0(cra) # encoding: [0xe7,0x80,0x00,0x00]
+jalr x1, x1
+# CHECK-NEXT: jal cra, 20 # encoding: [0xef,0x00,0x40,0x01]
+jal x1, 20
+# CHECK-NEXT: auipc cra, 10 # encoding: [0x97,0xa0,0x00,0x00]
+auipc x1, 10
+## We also allow zcheri 0.9.3 syntax using a c register
+# CHECK-NEXT: auipc cra, 10 # encoding: [0x97,0xa0,0x00,0x00]
+auipc c1, 10
+
+## Check that ABI register names work as expected
+# CHECK:      lc cra, 0(csp) # encoding: [0x8f,0x40,0x01,0x00]
+ly ra, 0(sp)
+# CHECK-NEXT: sc cra, 0(csp) # encoding: [0x23,0x40,0x11,0x00]
+sy ra, 0(sp)

--- a/llvm/test/MC/RISCV/cheri/bakewell/rvy-mnemonic-compat-intmode.s
+++ b/llvm/test/MC/RISCV/cheri/bakewell/rvy-mnemonic-compat-intmode.s
@@ -1,0 +1,24 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+zcheripurecap -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+zcheripurecap -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck %s
+
+## Check that RVY mnemonics are accepted and we can use X register names
+# CHECK: lc cra, 0(sp) # encoding: [0x8f,0x40,0x01,0x00]
+ly x1, 0(x2)
+# CHECK-NEXT: sc cra, 0(sp) # encoding: [0x23,0x40,0x11,0x00]
+sy x1, 0(x2)
+# CHECK-NEXT: lr.c cra, (sp) # encoding: [0xaf,0x40,0x01,0x10]
+lr.y x1, (x2)
+# CHECK-NEXT: lr.c.aq cra, (sp) # encoding: [0xaf,0x40,0x01,0x14]
+lr.y.aq x1, (x2)
+# CHECK-NEXT: sc.c gp, cgp, (sp) # encoding: [0xaf,0x41,0x31,0x18]
+sc.y x3, x3, (x2)
+# CHECK-NEXT: amoswap.c cra, cgp, (sp) # encoding: [0xaf,0x40,0x31,0x08]
+amoswap.y x1, x3, (x2)
+
+## Check that ABI register names work as expected
+# CHECK:      lc cra, 0(sp) # encoding: [0x8f,0x40,0x01,0x00]
+ly ra, 0(sp)
+# CHECK-NEXT: sc cra, 0(sp) # encoding: [0x23,0x40,0x11,0x00]
+sy ra, 0(sp)

--- a/llvm/test/MC/RISCV/cheri/bakewell/rvy-mnemonic-compat-invalid.s
+++ b/llvm/test/MC/RISCV/cheri/bakewell/rvy-mnemonic-compat-invalid.s
@@ -1,0 +1,82 @@
+# RUN: not llvm-mc < %s -triple=riscv32 -mattr=+c,+a,+zcheripurecap -riscv-no-aliases 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-INT %s --implicit-check-not="error:"
+# RUN: not llvm-mc < %s -triple=riscv64 -mattr=+c,+a,+zcheripurecap -riscv-no-aliases 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-INT %s --implicit-check-not="error:"
+# RUN: not llvm-mc < %s --defsym CAPMODE=1 -triple=riscv32 -mattr=+c,+a,+zcheripurecap,+cap-mode -riscv-no-aliases 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-CAP %s --implicit-check-not="error:"
+# RUN: not llvm-mc < %s --defsym CAPMODE=1 -triple=riscv64 -mattr=+c,+a,+zcheripurecap,+cap-mode -riscv-no-aliases 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-CAP %s --implicit-check-not="error:"
+
+## Check that RVY mnemonics reject DDC as a YBLD/YSS operand for compatibility with the RVY specification.
+# CHECK: :[[@LINE+1]]:10: error: operand must be a GPR other than x0
+ybld x1, ddc, c3
+# CHECK: :[[@LINE+1]]:14: error: operand must be a GPR
+ybld x1, x2, ddc
+# CHECK: :[[@LINE+1]]:9: error: operand must be a GPR other than x0
+yss x1, ddc, x3
+# CHECK: :[[@LINE+1]]:13: error: operand must be a GPR
+yss x1, x2, ddc
+
+## Check that in integer mode jumps reject capability registers.
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Pointer Mode
+jr c1
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Pointer Mode
+jalr c1, c2
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Pointer Mode
+jal c1, 20
+
+## Normal loads should reject C base registers.
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Pointer Mode
+lw x1, 0(c2)
+
+## Check that ZCheri standard instructions do not coerce GPR to GPCR.
+# CHECK: :[[@LINE+1]]:12: error: invalid operand for instruction
+gcperm x1, x2
+# CHECK: :[[@LINE+1]]:12: error: invalid operand for instruction
+gcbase x1, x2
+
+## Check that RVY mnemonics reject explicit c registers in both integer and capability modes.
+# CHECK: :[[@LINE+1]]:6: error: operand must be a GPR
+yadd c1, x2, x3
+# CHECK: :[[@LINE+1]]:10: error: operand must be a GPR
+yadd x1, c2, x3
+# CHECK: :[[@LINE+1]]:14: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
+yadd x1, x2, c3
+
+# CHECK: :[[@LINE+1]]:12: error: operand must be a GPR
+ypermr x1, c2
+
+# CHECK: :[[@LINE+1]]:6: error: operand must be a GPR
+yhiw c1, x2, x3
+# CHECK: :[[@LINE+1]]:10: error: operand must be a GPR
+yhiw x1, c2, x3
+
+# CHECK: :[[@LINE+1]]:6: error: operand must be a GPR
+ybld c1, x2, x3
+# CHECK: :[[@LINE+1]]:10: error: operand must be a GPR other than x0
+ybld x1, c2, x3
+# CHECK: :[[@LINE+1]]:14: error: operand must be a GPR
+ybld x1, x2, c3
+
+# CHECK: :[[@LINE+1]]:4: error: operand must be a GPR
+ly c1, 0(x2)
+# CHECK-INT: :[[@LINE+2]]:10: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:10: error: operand must be a GPR
+ly x1, 0(c2)
+
+# CHECK: :[[@LINE+1]]:4: error: operand must be a GPR
+sy c1, 0(x2)
+# CHECK-INT: :[[@LINE+2]]:10: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:10: error: operand must be a GPR
+sy x1, 0(c2)
+
+## Check that c.lysp and c.sysp reject csp instead of sp.
+# CHECK-INT: :[[@LINE+2]]:15: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:15: error: operand must be sp
+c.lysp a0, 16(csp)
+# CHECK-INT: :[[@LINE+2]]:15: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:15: error: operand must be sp
+c.sysp a0, 16(csp)
+## Check that c.ly rejects csp (instead of sp).
+# CHECK-INT: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:13: error: operand must be a GPR
+c.ly a0, 16(ca0)
+# CHECK-INT: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:13: error: operand must be a GPR
+c.sy a0, 16(ca0)

--- a/llvm/test/MC/RISCV/cheri/bakewell/rvzcherihybrid-jalr.s
+++ b/llvm/test/MC/RISCV/cheri/bakewell/rvzcherihybrid-jalr.s
@@ -88,20 +88,20 @@ jr ca1
 # CHECK-ASM: encoding: [0x67,0x80,0x00,0x00]
 ret
 
-# CHECK-ASM-AND-OBJ: jalr.mode a0, 0(a0)
-# CHECK-ASM: encoding: [0x67,0x15,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr ca0, 0(ca0)
+# CHECK-ASM: encoding: [0x67,0x05,0x05,0x00]
 jalr a0, 0(a0)
 
-# CHECK-ASM-AND-OBJ: jalr.mode a0, 0(a0)
-# CHECK-ASM: encoding: [0x67,0x15,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr ca0, 0(ca0)
+# CHECK-ASM: encoding: [0x67,0x05,0x05,0x00]
 jalr a0, a0
 
-# CHECK-ASM-AND-OBJ: jalr.mode ra, 0(a0)
-# CHECK-ASM: encoding: [0xe7,0x10,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr cra, 0(ca0)
+# CHECK-ASM: encoding: [0xe7,0x00,0x05,0x00]
 jalr a0
 
-# CHECK-ASM-AND-OBJ: jalr.mode zero, 0(a0)
-# CHECK-ASM: encoding: [0x67,0x10,0x05,0x00]
+# CHECK-ASM-AND-OBJ: jalr cnull, 0(ca0)
+# CHECK-ASM: encoding: [0x67,0x00,0x05,0x00]
 jr a0
 
 # CHECK-ASM-AND-OBJ: jalr.mode zero, 0(ra)

--- a/llvm/test/MC/RISCV/cheri/bakewell/zcheripurecap-invalid.s
+++ b/llvm/test/MC/RISCV/cheri/bakewell/zcheripurecap-invalid.s
@@ -22,7 +22,6 @@ cclear      1, 0x42          # CHECK: <stdin>:[[#@LINE]]:1:  error: instruction 
 fpclear     1, 0x42          # CHECK: <stdin>:[[#@LINE]]:1:  error: instruction requires the following: CHERI Extension
 crrl        a0, a0           # CHECK: <stdin>:[[#@LINE]]:1:  error: instruction requires the following: CHERI Extension
 cloadtags   a0, (ca0)        # CHECK: <stdin>:[[#@LINE]]:1:  error: instruction requires the following: CHERI Extension
-jalr        a0, 42(a0)       # CHECK: <stdin>:[[#@LINE]]:1:  error: instruction requires the following: Integer Pointer Mode
 jalr.mode   ca0, 0(ca0)      # CHECK: <stdin>:[[#@LINE]]:1:  error: instruction requires the following: 'Zcherihybrid' (Backwards compatiblity for 'Zcheripurecap' with RISCV), Integer Pointer Mode
 # With scbndsi we sadly don't get the warning for smaller values as the asm
 # parser will try and parse CSetBounds and will succeed - warning instead about

--- a/llvm/test/MC/RISCV/cheri/rv32axcheri-cap-mode-invalid.s
+++ b/llvm/test/MC/RISCV/cheri/rv32axcheri-cap-mode-invalid.s
@@ -5,7 +5,6 @@ amoswap.w a1, a2, c3 # CHECK: :[[@LINE]]:19: error: expected '(' or optional int
 amomin.w a1, a2, 1 # CHECK: :[[@LINE]]:20: error: expected '(' after optional integer offset
 amomin.w a1, a2, 1(c3) # CHECK: :[[@LINE]]:18: error: optional integer offset must be 0
 lr.w a4, c5 # CHECK: :[[@LINE]]:10: error: expected '(' or optional integer offset
-lr.w a4, (a5) # CHECK: :[[@LINE]]:1: error: instruction requires the following: Integer Pointer Mode
 
 # Only .aq, .rl, and .aqrl suffixes are valid
 amoxor.w.rlqa a2, a3, (c4) # CHECK: :[[@LINE]]:1: error: unrecognized instruction mnemonic

--- a/llvm/test/MC/RISCV/cheri/rv32cxcheri-cap-mode-invalid.s
+++ b/llvm/test/MC/RISCV/cheri/rv32cxcheri-cap-mode-invalid.s
@@ -39,8 +39,7 @@ c.sw a5, 1(ca3)
 c.csw a5, 4(a3)
 # CHECK: <stdin>:[[#@LINE-1]]:13: error: invalid operand for instruction
 c.sw a5, 4(a3)
-# CHECK-NO-C: <stdin>:[[#@LINE-1]]:1: error: instruction requires the following: 'C' (Compressed Instructions) or 'Zca' (part of the C extension, excluding compressed floating point loads/stores), Integer Pointer Mode
-# CHECK-C: <stdin>:[[#@LINE-2]]:1: error: instruction requires the following: Integer Pointer Mode
+# CHECK-NO-C: <stdin>:[[#@LINE-1]]:1: error: instruction requires the following: 'C' (Compressed Instructions){{$}}
 
 # Bad operands:
 c.cjalr a1
@@ -48,11 +47,9 @@ c.cjalr a1
 c.cjr a1
 # CHECK: <stdin>:[[#@LINE-1]]:7: error: invalid operand for instruction
 c.jalr a1
-# CHECK-C: <stdin>:[[#@LINE-1]]:1: error: instruction requires the following: Integer Pointer Mode{{$}}
-# CHECK-NO-C: <stdin>:[[#@LINE-2]]:1: error: instruction requires the following: 'C' (Compressed Instructions) or 'Zca' (part of the C extension, excluding compressed floating point loads/stores), Integer Pointer Mode{{$}}
+# CHECK-NO-C: <stdin>:[[#@LINE-1]]:1: error: instruction requires the following: 'C' (Compressed Instructions){{$}}
 c.jr a1
-# CHECK-C: <stdin>:[[#@LINE-1]]:1: error: instruction requires the following: Integer Pointer Mode{{$}}
-# CHECK-NO-C: <stdin>:[[#@LINE-2]]:1: error: instruction requires the following: 'C' (Compressed Instructions) or 'Zca' (part of the C extension, excluding compressed floating point loads/stores), Integer Pointer Mode{{$}}
+# CHECK-NO-C: <stdin>:[[#@LINE-1]]:1: error: instruction requires the following: 'C' (Compressed Instructions){{$}}
 c.csc a5, 16(ca3)
 # CHECK: <stdin>:[[#@LINE-1]]:7: error: invalid operand for instruction
 c.csc ca5, 16(a3)

--- a/llvm/test/MC/RISCV/cheri/rv32cxcheri-cap-mode-valid.s
+++ b/llvm/test/MC/RISCV/cheri/rv32cxcheri-cap-mode-valid.s
@@ -33,6 +33,9 @@ c.csw a5, 124(ca3)
 # CHECK-ASM-AND-OBJ: {{[[:<:]]}}c.sw a5, 124(ca3)
 # CHECK-ASM-SAME: encoding: [0xfc,0xde]
 c.sw a5, 124(ca3)
+# CHECK-ASM-AND-OBJ: {{[[:<:]]}}c.sw a5, 4(ca3)
+# CHECK-ASM-SAME: encoding: [0xdc,0xc2]
+c.sw a5, 4(a3)
 
 # CHECK-ASM-AND-OBJ: {{[[:<:]]}}c.jr ca7
 # CHECK-ASM-SAME: encoding: [0x82,0x88]

--- a/llvm/test/MC/RISCV/cheri/rv64axcheri-cap-mode-invalid.s
+++ b/llvm/test/MC/RISCV/cheri/rv64axcheri-cap-mode-invalid.s
@@ -5,7 +5,6 @@ amoswap.d a1, a2, ca3 # CHECK: :[[@LINE]]:19: error: expected '(' or optional in
 amomin.d a1, a2, 1 # CHECK: :[[@LINE]]:20: error: expected '(' after optional integer offset
 amomin.d a1, a2, 1(ca3) # CHECK: :[[@LINE]]:18: error: optional integer offset must be 0
 lr.d a4, a5 # CHECK: :[[@LINE]]:10: error: expected '(' or optional integer offset
-lr.d a4, (a5) # CHECK: :[[@LINE]]:1: error: instruction requires the following: Integer Pointer Mode
 
 # Only .aq, .rl, and .aqrl suffixes are valid
 amoxor.d.rlqa a2, a3, (ca4) # CHECK: :[[@LINE]]:1: error: unrecognized instruction mnemonic

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-both-modes.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-both-modes.s
@@ -1,61 +1,61 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri -riscv-no-aliases -show-encoding \
-# RUN:     | FileCheck -check-prefixes=CHECK %s
+# RUN:     | FileCheck --check-prefixes=CHECK %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri -riscv-no-aliases -show-encoding \
-# RUN:     | FileCheck -check-prefixes=CHECK %s
+# RUN:     | FileCheck --check-prefixes=CHECK %s
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
-# RUN:     | FileCheck -check-prefixes=CHECK %s
+# RUN:     | FileCheck --check-prefixes=CHECK %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
-# RUN:     | FileCheck -check-prefixes=CHECK %s
+# RUN:     | FileCheck --check-prefixes=CHECK %s
 
 # CHECK: cgetperm ra, csp # encoding: [0xdb,0x00,0x01,0xfe]
-ypermr x1, c2
+ypermr x1, x2
 # CHECK-NEXT: cgettype ra, csp # encoding: [0xdb,0x00,0x11,0xfe]
-ytyper x1, c2
+ytyper x1, x2
 # CHECK-NEXT: cgetbase ra, csp # encoding: [0xdb,0x00,0x21,0xfe]
-ybaser x1, c2
+ybaser x1, x2
 # CHECK-NEXT: cgetlen ra, csp # encoding: [0xdb,0x00,0x31,0xfe]
-ylenr x1, c2
+ylenr x1, x2
 # CHECK-NEXT: cgettag ra, csp # encoding: [0xdb,0x00,0x41,0xfe]
-ytagr x1, c2
+ytagr x1, x2
 # CHECK-NEXT: cgethigh ra, csp # encoding: [0xdb,0x00,0x71,0xff]
-yhir x1, c2
+yhir x1, x2
 # CHECK-NEXT: csetaddr cra, csp, gp # encoding: [0xdb,0x00,0x31,0x20]
-yaddrw c1, c2, x3
+yaddrw x1, x2, x3
 # CHECK-NEXT: csethigh cra, csp, gp # encoding: [0xdb,0x00,0x31,0x2c]
-yhiw c1, c2, x3
+yhiw x1, x2, x3
 # CHECK-NEXT: cincoffset cra, csp, gp # encoding: [0xdb,0x00,0x31,0x22]
-yadd c1, c2, x3
+yadd x1, x2, x3
 # CHECK-NEXT: cincoffset cra, csp, -173 # encoding: [0xdb,0x10,0x31,0xf5]
-yaddi c1, c2, -173
+yaddi x1, x2, -173
 # CHECK-NEXT: cincoffset cra, csp, -173 # encoding: [0xdb,0x10,0x31,0xf5]
-yadd c1, c2, -173
+yadd x1, x2, -173
 # CHECK-NEXT: csealentry cra, csp # encoding: [0xdb,0x00,0x11,0xff]
-ysentry c1, c2
+ysentry x1, x2
 # CHECK-NEXT: cbuildcap cra, csp, cgp # encoding: [0xdb,0x00,0x31,0x3a]
-ybld c1, c2, c3
+ybld x1, x2, x3
 # CHECK-NEXT: csetbounds cra, csp, gp # encoding: [0xdb,0x00,0x31,0x10]
-ybndsrw c1, c2, x3
+ybndsrw x1, x2, x3
 # CHECK-NEXT: csetboundsexact cra, csp, gp # encoding: [0xdb,0x00,0x31,0x12]
-ybndsw c1, c2, x3
+ybndsw x1, x2, x3
 # CHECK-NEXT: csetbounds cra, csp, 3029 # encoding: [0xdb,0x20,0x51,0xbd]
-ybndsw c1, c2, 0xbd5
+ybndsw x1, x2, 0xbd5
 # CHECK-NEXT: csetbounds cra, csp, 3029 # encoding: [0xdb,0x20,0x51,0xbd]
-ybndswi c1, c2, 0xbd5
+ybndswi x1, x2, 0xbd5
 # CHECK-NEXT: cmove cra, csp # encoding: [0xdb,0x00,0xa1,0xfe]
-ymv c1, c2
+ymv x1, x2
 # CHECK-NEXT: crepresentablealignmentmask ra, sp # encoding: [0xdb,0x00,0x91,0xfe]
 yamask x1, x2
 # CHECK-NEXT: ctestsubset ra, csp, cgp # encoding: [0xdb,0x00,0x31,0x40]
-yss x1, c2, c3
+yss x1, x2, x3
 # CHECK-NEXT: csetequalexact ra, csp, cgp # encoding: [0xdb,0x00,0x31,0x42]
-yeq x1, c2, c3
+yeq x1, x2, x3
 
 ## Check that ABI register names work as expected
 # CHECK: cgetperm ra, csp # encoding: [0xdb,0x00,0x01,0xfe]
-ypermr ra, csp
+ypermr ra, sp
 # CHECK-NEXT: cincoffset cra, csp, -173 # encoding: [0xdb,0x10,0x31,0xf5]
-yaddi cra, csp, -173
+yaddi ra, sp, -173
 # CHECK-NEXT: csealentry cra, csp # encoding: [0xdb,0x00,0x11,0xff]
-ysentry cra, csp
+ysentry ra, sp
 # CHECK-NEXT: cbuildcap cra, csp, cgp # encoding: [0xdb,0x00,0x31,0x3a]
-ybld cra, csp, cgp
+ybld ra, sp, gp

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-both-modes.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-both-modes.s
@@ -1,0 +1,61 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK %s
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK %s
+
+# CHECK: cgetperm ra, csp # encoding: [0xdb,0x00,0x01,0xfe]
+ypermr x1, c2
+# CHECK-NEXT: cgettype ra, csp # encoding: [0xdb,0x00,0x11,0xfe]
+ytyper x1, c2
+# CHECK-NEXT: cgetbase ra, csp # encoding: [0xdb,0x00,0x21,0xfe]
+ybaser x1, c2
+# CHECK-NEXT: cgetlen ra, csp # encoding: [0xdb,0x00,0x31,0xfe]
+ylenr x1, c2
+# CHECK-NEXT: cgettag ra, csp # encoding: [0xdb,0x00,0x41,0xfe]
+ytagr x1, c2
+# CHECK-NEXT: cgethigh ra, csp # encoding: [0xdb,0x00,0x71,0xff]
+yhir x1, c2
+# CHECK-NEXT: csetaddr cra, csp, gp # encoding: [0xdb,0x00,0x31,0x20]
+yaddrw c1, c2, x3
+# CHECK-NEXT: csethigh cra, csp, gp # encoding: [0xdb,0x00,0x31,0x2c]
+yhiw c1, c2, x3
+# CHECK-NEXT: cincoffset cra, csp, gp # encoding: [0xdb,0x00,0x31,0x22]
+yadd c1, c2, x3
+# CHECK-NEXT: cincoffset cra, csp, -173 # encoding: [0xdb,0x10,0x31,0xf5]
+yaddi c1, c2, -173
+# CHECK-NEXT: cincoffset cra, csp, -173 # encoding: [0xdb,0x10,0x31,0xf5]
+yadd c1, c2, -173
+# CHECK-NEXT: csealentry cra, csp # encoding: [0xdb,0x00,0x11,0xff]
+ysentry c1, c2
+# CHECK-NEXT: cbuildcap cra, csp, cgp # encoding: [0xdb,0x00,0x31,0x3a]
+ybld c1, c2, c3
+# CHECK-NEXT: csetbounds cra, csp, gp # encoding: [0xdb,0x00,0x31,0x10]
+ybndsrw c1, c2, x3
+# CHECK-NEXT: csetboundsexact cra, csp, gp # encoding: [0xdb,0x00,0x31,0x12]
+ybndsw c1, c2, x3
+# CHECK-NEXT: csetbounds cra, csp, 3029 # encoding: [0xdb,0x20,0x51,0xbd]
+ybndsw c1, c2, 0xbd5
+# CHECK-NEXT: csetbounds cra, csp, 3029 # encoding: [0xdb,0x20,0x51,0xbd]
+ybndswi c1, c2, 0xbd5
+# CHECK-NEXT: cmove cra, csp # encoding: [0xdb,0x00,0xa1,0xfe]
+ymv c1, c2
+# CHECK-NEXT: crepresentablealignmentmask ra, sp # encoding: [0xdb,0x00,0x91,0xfe]
+yamask x1, x2
+# CHECK-NEXT: ctestsubset ra, csp, cgp # encoding: [0xdb,0x00,0x31,0x40]
+yss x1, c2, c3
+# CHECK-NEXT: csetequalexact ra, csp, cgp # encoding: [0xdb,0x00,0x31,0x42]
+yeq x1, c2, c3
+
+## Check that ABI register names work as expected
+# CHECK: cgetperm ra, csp # encoding: [0xdb,0x00,0x01,0xfe]
+ypermr ra, csp
+# CHECK-NEXT: cincoffset cra, csp, -173 # encoding: [0xdb,0x10,0x31,0xf5]
+yaddi cra, csp, -173
+# CHECK-NEXT: csealentry cra, csp # encoding: [0xdb,0x00,0x11,0xff]
+ysentry cra, csp
+# CHECK-NEXT: cbuildcap cra, csp, cgp # encoding: [0xdb,0x00,0x31,0x3a]
+ybld cra, csp, cgp

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-capmode.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-capmode.s
@@ -1,31 +1,63 @@
-# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
-# RUN:     | FileCheck -check-prefixes=CHECK-32 %s
-# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
-# RUN:     | FileCheck -check-prefixes=CHECK-64 %s
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+f,+d,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck --check-prefixes=CHECK,CHECK-32 %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+f,+d,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck --check-prefixes=CHECK,CHECK-64 %s
 
+## Check that RVY mnemonics are accepted and we can use X register names
 # CHECK-32:      lc cra, 0(csp) # encoding: [0x83,0x30,0x01,0x00]
 # CHECK-64:      lc cra, 0(csp) # encoding: [0x8f,0x20,0x01,0x00]
-ly c1, 0(c2)
+ly x1, 0(x2)
 # CHECK-32-NEXT: sc cra, 0(csp) # encoding: [0x23,0x30,0x11,0x00]
 # CHECK-64-NEXT: sc cra, 0(csp) # encoding: [0x23,0x40,0x11,0x00]
-sy c1, 0(c2)
+sy x1, 0(x2)
 # CHECK-32-NEXT: lr.c cra, (csp) # encoding: [0xaf,0x30,0x01,0x10]
 # CHECK-64-NEXT: lr.c cra, (csp) # encoding: [0xaf,0x40,0x01,0x10]
-lr.y c1, (c2)
+lr.y x1, (x2)
 # CHECK-32-NEXT: lr.c.aq cra, (csp) # encoding: [0xaf,0x30,0x01,0x14]
 # CHECK-64-NEXT: lr.c.aq cra, (csp) # encoding: [0xaf,0x40,0x01,0x14]
-lr.y.aq c1, (c2)
+lr.y.aq x1, (x2)
 # CHECK-32-NEXT: sc.c gp, cgp, (csp) # encoding: [0xaf,0x31,0x31,0x18]
 # CHECK-64-NEXT: sc.c gp, cgp, (csp) # encoding: [0xaf,0x41,0x31,0x18]
-sc.y x3, c3, (c2)
+sc.y x3, x3, (x2)
 # CHECK-32-NEXT: amoswap.c cra, cgp, (csp) # encoding: [0xaf,0x30,0x31,0x08]
 # CHECK-64-NEXT: amoswap.c cra, cgp, (csp) # encoding: [0xaf,0x40,0x31,0x08]
-amoswap.y c1, c3, (c2)
+amoswap.y x1, x3, (x2)
+
+## In capability mode, standard integer memory access instructions (lb/lw) use capability
+## base registers. We test here that unprefixed integer register names (x2) are correctly
+## coerced to capability base registers (csp) by the parser, even though these are not new instructions.
+# CHECK:      lb ra, 0(csp) # encoding: [0x83,0x00,0x01,0x00]
+lb x1, 0(x2)
+# CHECK-NEXT: lw ra, 0(csp) # encoding: [0x83,0x20,0x01,0x00]
+lw x1, 0(x2)
+# CHECK-NEXT: amoadd.w ra, gp, (csp) # encoding: [0xaf,0x20,0x31,0x00]
+amoadd.w x1, x3, (x2)
+# CHECK-NEXT: flw ft1, 0(csp) # encoding: [0x87,0x20,0x01,0x00]
+flw ft1, 0(x2)
+# CHECK-NEXT: fld fa0, 0(csp) # encoding: [0x07,0x35,0x01,0x00]
+fld fa0, 0(x2)
+# CHECK-NEXT: fsw ft1, 0(csp) # encoding: [0x27,0x20,0x11,0x00]
+fsw ft1, 0(x2)
+# CHECK-NEXT: fsd fa0, 0(csp) # encoding: [0x27,0x30,0xa1,0x00]
+fsd fa0, 0(x2)
+
+## Same for jump instructions
+# CHECK:      jalr cnull, 0(cra) # encoding: [0x67,0x80,0x00,0x00]
+jr x1
+# CHECK-NEXT: jalr cra, 0(cra) # encoding: [0xe7,0x80,0x00,0x00]
+jalr x1, x1
+# CHECK-NEXT: jal cra, 20 # encoding: [0xef,0x00,0x40,0x01]
+jal x1, 20
+# CHECK-NEXT: auipcc cra, 10 # encoding: [0x97,0xa0,0x00,0x00]
+auipc x1, 10
+## We also allow zcheri 0.9.3 syntax using a c register
+# CHECK-NEXT: auipcc cra, 10 # encoding: [0x97,0xa0,0x00,0x00]
+auipc c1, 10
 
 ## Check that ABI register names work as expected
 # CHECK-32:      lc cra, 0(csp) # encoding: [0x83,0x30,0x01,0x00]
 # CHECK-64:      lc cra, 0(csp) # encoding: [0x8f,0x20,0x01,0x00]
-ly cra, 0(csp)
+ly ra, 0(sp)
 # CHECK-32-NEXT: sc cra, 0(csp) # encoding: [0x23,0x30,0x11,0x00]
 # CHECK-64-NEXT: sc cra, 0(csp) # encoding: [0x23,0x40,0x11,0x00]
-sy cra, 0(csp)
+sy ra, 0(sp)

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-capmode.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-capmode.s
@@ -1,0 +1,31 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-32 %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri,+cap-mode -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-64 %s
+
+# CHECK-32:      lc cra, 0(csp) # encoding: [0x83,0x30,0x01,0x00]
+# CHECK-64:      lc cra, 0(csp) # encoding: [0x8f,0x20,0x01,0x00]
+ly c1, 0(c2)
+# CHECK-32-NEXT: sc cra, 0(csp) # encoding: [0x23,0x30,0x11,0x00]
+# CHECK-64-NEXT: sc cra, 0(csp) # encoding: [0x23,0x40,0x11,0x00]
+sy c1, 0(c2)
+# CHECK-32-NEXT: lr.c cra, (csp) # encoding: [0xaf,0x30,0x01,0x10]
+# CHECK-64-NEXT: lr.c cra, (csp) # encoding: [0xaf,0x40,0x01,0x10]
+lr.y c1, (c2)
+# CHECK-32-NEXT: lr.c.aq cra, (csp) # encoding: [0xaf,0x30,0x01,0x14]
+# CHECK-64-NEXT: lr.c.aq cra, (csp) # encoding: [0xaf,0x40,0x01,0x14]
+lr.y.aq c1, (c2)
+# CHECK-32-NEXT: sc.c gp, cgp, (csp) # encoding: [0xaf,0x31,0x31,0x18]
+# CHECK-64-NEXT: sc.c gp, cgp, (csp) # encoding: [0xaf,0x41,0x31,0x18]
+sc.y x3, c3, (c2)
+# CHECK-32-NEXT: amoswap.c cra, cgp, (csp) # encoding: [0xaf,0x30,0x31,0x08]
+# CHECK-64-NEXT: amoswap.c cra, cgp, (csp) # encoding: [0xaf,0x40,0x31,0x08]
+amoswap.y c1, c3, (c2)
+
+## Check that ABI register names work as expected
+# CHECK-32:      lc cra, 0(csp) # encoding: [0x83,0x30,0x01,0x00]
+# CHECK-64:      lc cra, 0(csp) # encoding: [0x8f,0x20,0x01,0x00]
+ly cra, 0(csp)
+# CHECK-32-NEXT: sc cra, 0(csp) # encoding: [0x23,0x30,0x11,0x00]
+# CHECK-64-NEXT: sc cra, 0(csp) # encoding: [0x23,0x40,0x11,0x00]
+sy cra, 0(csp)

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-capmode.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-capmode.s
@@ -48,10 +48,10 @@ jr x1
 jalr x1, x1
 # CHECK-NEXT: jal cra, 20 # encoding: [0xef,0x00,0x40,0x01]
 jal x1, 20
-# CHECK-NEXT: auipcc cra, 10 # encoding: [0x97,0xa0,0x00,0x00]
+# CHECK-NEXT: auipc cra, 10 # encoding: [0x97,0xa0,0x00,0x00]
 auipc x1, 10
 ## We also allow zcheri 0.9.3 syntax using a c register
-# CHECK-NEXT: auipcc cra, 10 # encoding: [0x97,0xa0,0x00,0x00]
+# CHECK-NEXT: auipc cra, 10 # encoding: [0x97,0xa0,0x00,0x00]
 auipc c1, 10
 
 ## Check that ABI register names work as expected

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-intmode.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-intmode.s
@@ -1,31 +1,32 @@
 # RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri -riscv-no-aliases -show-encoding \
-# RUN:     | FileCheck -check-prefixes=CHECK-32 %s
+# RUN:     | FileCheck --check-prefixes=CHECK-32 %s
 # RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri -riscv-no-aliases -show-encoding \
-# RUN:     | FileCheck -check-prefixes=CHECK-64 %s
+# RUN:     | FileCheck --check-prefixes=CHECK-64 %s
 
+## Check that RVY mnemonics are accepted and we can use X register names
 # CHECK-32: lc cra, 0(sp) # encoding: [0x83,0x30,0x01,0x00]
 # CHECK-64: lc cra, 0(sp) # encoding: [0x8f,0x20,0x01,0x00]
-ly c1, 0(x2)
+ly x1, 0(x2)
 # CHECK-32-NEXT: sc cra, 0(sp) # encoding: [0x23,0x30,0x11,0x00]
 # CHECK-64-NEXT: sc cra, 0(sp) # encoding: [0x23,0x40,0x11,0x00]
-sy c1, 0(x2)
+sy x1, 0(x2)
 # CHECK-32-NEXT: lr.c cra, (sp) # encoding: [0xaf,0x30,0x01,0x10]
 # CHECK-64-NEXT: lr.c cra, (sp) # encoding: [0xaf,0x40,0x01,0x10]
-lr.y c1, (x2)
+lr.y x1, (x2)
 # CHECK-32-NEXT: lr.c.aq cra, (sp) # encoding: [0xaf,0x30,0x01,0x14]
 # CHECK-64-NEXT: lr.c.aq cra, (sp) # encoding: [0xaf,0x40,0x01,0x14]
-lr.y.aq c1, (x2)
+lr.y.aq x1, (x2)
 # CHECK-32-NEXT: sc.c gp, cgp, (sp) # encoding: [0xaf,0x31,0x31,0x18]
 # CHECK-64-NEXT: sc.c gp, cgp, (sp) # encoding: [0xaf,0x41,0x31,0x18]
-sc.y x3, c3, (x2)
+sc.y x3, x3, (x2)
 # CHECK-32-NEXT: amoswap.c cra, cgp, (sp) # encoding: [0xaf,0x30,0x31,0x08]
 # CHECK-64-NEXT: amoswap.c cra, cgp, (sp) # encoding: [0xaf,0x40,0x31,0x08]
-amoswap.y c1, c3, (x2)
+amoswap.y x1, x3, (x2)
 
 ## Check that ABI register names work as expected
 # CHECK-32:      lc cra, 0(sp) # encoding: [0x83,0x30,0x01,0x00]
 # CHECK-64:      lc cra, 0(sp) # encoding: [0x8f,0x20,0x01,0x00]
-ly cra, 0(sp)
+ly ra, 0(sp)
 # CHECK-32-NEXT: sc cra, 0(sp) # encoding: [0x23,0x30,0x11,0x00]
 # CHECK-64-NEXT: sc cra, 0(sp) # encoding: [0x23,0x40,0x11,0x00]
-sy cra, 0(sp)
+sy ra, 0(sp)

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-intmode.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-intmode.s
@@ -1,0 +1,31 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-32 %s
+# RUN: llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-64 %s
+
+# CHECK-32: lc cra, 0(sp) # encoding: [0x83,0x30,0x01,0x00]
+# CHECK-64: lc cra, 0(sp) # encoding: [0x8f,0x20,0x01,0x00]
+ly c1, 0(x2)
+# CHECK-32-NEXT: sc cra, 0(sp) # encoding: [0x23,0x30,0x11,0x00]
+# CHECK-64-NEXT: sc cra, 0(sp) # encoding: [0x23,0x40,0x11,0x00]
+sy c1, 0(x2)
+# CHECK-32-NEXT: lr.c cra, (sp) # encoding: [0xaf,0x30,0x01,0x10]
+# CHECK-64-NEXT: lr.c cra, (sp) # encoding: [0xaf,0x40,0x01,0x10]
+lr.y c1, (x2)
+# CHECK-32-NEXT: lr.c.aq cra, (sp) # encoding: [0xaf,0x30,0x01,0x14]
+# CHECK-64-NEXT: lr.c.aq cra, (sp) # encoding: [0xaf,0x40,0x01,0x14]
+lr.y.aq c1, (x2)
+# CHECK-32-NEXT: sc.c gp, cgp, (sp) # encoding: [0xaf,0x31,0x31,0x18]
+# CHECK-64-NEXT: sc.c gp, cgp, (sp) # encoding: [0xaf,0x41,0x31,0x18]
+sc.y x3, c3, (x2)
+# CHECK-32-NEXT: amoswap.c cra, cgp, (sp) # encoding: [0xaf,0x30,0x31,0x08]
+# CHECK-64-NEXT: amoswap.c cra, cgp, (sp) # encoding: [0xaf,0x40,0x31,0x08]
+amoswap.y c1, c3, (x2)
+
+## Check that ABI register names work as expected
+# CHECK-32:      lc cra, 0(sp) # encoding: [0x83,0x30,0x01,0x00]
+# CHECK-64:      lc cra, 0(sp) # encoding: [0x8f,0x20,0x01,0x00]
+ly cra, 0(sp)
+# CHECK-32-NEXT: sc cra, 0(sp) # encoding: [0x23,0x30,0x11,0x00]
+# CHECK-64-NEXT: sc cra, 0(sp) # encoding: [0x23,0x40,0x11,0x00]
+sy cra, 0(sp)

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-invalid.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-invalid.s
@@ -1,12 +1,100 @@
-# RUN: not llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri -riscv-no-aliases 2>&1 | FileCheck %s
-# RUN: not llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri -riscv-no-aliases 2>&1 | FileCheck %s
+# RUN: not llvm-mc < %s -triple=riscv32 -mattr=+c,+a,+xcheri -riscv-no-aliases 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-INT %s --implicit-check-not="error:"
+# RUN: not llvm-mc < %s -triple=riscv64 -mattr=+c,+a,+xcheri -riscv-no-aliases 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-INT %s --implicit-check-not="error:"
+# RUN: not llvm-mc < %s --defsym CAPMODE=1 -triple=riscv32 -mattr=+c,+a,+xcheri,+cap-mode -riscv-no-aliases 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-CAP %s --implicit-check-not="error:"
+# RUN: not llvm-mc < %s --defsym CAPMODE=1 -triple=riscv64 -mattr=+c,+a,+xcheri,+cap-mode -riscv-no-aliases 2>&1 | FileCheck --check-prefixes=CHECK,CHECK-CAP %s --implicit-check-not="error:"
 
-## Check that RVY mnemonics reject DDC as an operand for compatibility with the RVY specification.
-# CHECK: :[[@LINE+1]]:10: error: invalid operand for instruction
-ybld c1, ddc, c3
+## Check that RVY mnemonics reject DDC as a YBLD/YSS operand for compatibility with the RVY specification.
+# CHECK: :[[@LINE+1]]:10: error: operand must be a GPR other than x0
+ybld x1, ddc, c3
+# CHECK: :[[@LINE+1]]:14: error: operand must be a GPR
+ybld x1, x2, ddc
+# CHECK: :[[@LINE+1]]:9: error: operand must be a GPR other than x0
+yss x1, ddc, x3
+# CHECK: :[[@LINE+1]]:13: error: operand must be a GPR
+yss x1, x2, ddc
+
+## Check that in integer mode jumps reject capability registers.
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Mode
+jr c1
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Mode
+jalr c1, c2
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Mode
+jal c1, 20
+
+## Normal loads should reject C base registers.
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Mode
+lw x1, 0(c2)
+
+## Check that XCheri mnemonics do not coerce arguments.
 # CHECK: :[[@LINE+1]]:14: error: invalid operand for instruction
-ybld c1, c2, ddc
+cgetbase x1, x2
+# CHECK: :[[@LINE+1]]:14: error: invalid operand for instruction
+cgetperm x1, x2
+# CHECK: :[[@LINE+1]]:12: error: invalid operand for instruction
+csetbounds x1, x2, x3
+# CHECK: :[[@LINE+1]]:10: error: invalid operand for instruction
+csetaddr x1, x2, x3
 # CHECK: :[[@LINE+1]]:9: error: invalid operand for instruction
-yss x1, ddc, c3
-# CHECK: :[[@LINE+1]]:13: error: invalid operand for instruction
-yss x1, c2, ddc
+cinvoke x1, x2
+
+
+## Check that we don't coerce arguments for .ddc and .cap instructions in integer and capability modes
+# CHECK: :[[@LINE+1]]:8: error: invalid operand for instruction
+lc.ddc x1, 0(x2)
+# CHECK: :[[@LINE+1]]:8: error: invalid operand for instruction
+sc.ddc x1, 0(x2)
+# CHECK: :[[@LINE+1]]:14: error: invalid operand for instruction
+lc.cap c1, 0(x2)
+# CHECK: :[[@LINE+1]]:14: error: invalid operand for instruction
+sc.cap c1, 0(x2)
+
+## Check that RVY mnemonics reject explicit c registers in both integer and capability modes.
+# CHECK: :[[@LINE+1]]:6: error: operand must be a GPR
+yadd c1, x2, x3
+# CHECK: :[[@LINE+1]]:10: error: operand must be a GPR
+yadd x1, c2, x3
+# CHECK: :[[@LINE+1]]:14: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
+yadd x1, x2, c3
+
+# CHECK: :[[@LINE+1]]:12: error: operand must be a GPR
+ypermr x1, c2
+
+# CHECK: :[[@LINE+1]]:6: error: operand must be a GPR
+yhiw c1, x2, x3
+# CHECK: :[[@LINE+1]]:10: error: operand must be a GPR
+yhiw x1, c2, x3
+
+# CHECK: :[[@LINE+1]]:6: error: operand must be a GPR
+ybld c1, x2, x3
+# CHECK: :[[@LINE+1]]:10: error: operand must be a GPR other than x0
+ybld x1, c2, x3
+# CHECK: :[[@LINE+1]]:14: error: operand must be a GPR
+ybld x1, x2, c3
+
+# CHECK: :[[@LINE+1]]:4: error: operand must be a GPR
+ly c1, 0(x2)
+# CHECK-INT: :[[@LINE+2]]:10: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:10: error: operand must be a GPR
+ly x1, 0(c2)
+
+# CHECK: :[[@LINE+1]]:4: error: operand must be a GPR
+sy c1, 0(x2)
+# CHECK-INT: :[[@LINE+2]]:10: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:10: error: operand must be a GPR
+sy x1, 0(c2)
+
+## Check that c.lysp and c.sysp reject csp instead of sp.
+# CHECK-INT: :[[@LINE+2]]:15: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:15: error: operand must be sp
+c.lysp a0, 16(csp)
+# CHECK-INT: :[[@LINE+2]]:15: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:15: error: operand must be sp
+c.sysp a0, 16(csp)
+## Check that c.ly rejects csp (instead of sp).
+# CHECK-INT: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:13: error: operand must be a GPR
+c.ly a0, 16(ca0)
+# CHECK-INT: :[[@LINE+2]]:13: error: invalid operand for instruction
+# CHECK-CAP: :[[@LINE+1]]:13: error: operand must be a GPR
+c.sy a0, 16(ca0)
+

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-invalid.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-invalid.s
@@ -1,0 +1,12 @@
+# RUN: not llvm-mc %s -triple=riscv32 -mattr=+a,+xcheri -riscv-no-aliases 2>&1 | FileCheck %s
+# RUN: not llvm-mc %s -triple=riscv64 -mattr=+a,+xcheri -riscv-no-aliases 2>&1 | FileCheck %s
+
+## Check that RVY mnemonics reject DDC as an operand for compatibility with the RVY specification.
+# CHECK: :[[@LINE+1]]:10: error: invalid operand for instruction
+ybld c1, ddc, c3
+# CHECK: :[[@LINE+1]]:14: error: invalid operand for instruction
+ybld c1, c2, ddc
+# CHECK: :[[@LINE+1]]:9: error: invalid operand for instruction
+yss x1, ddc, c3
+# CHECK: :[[@LINE+1]]:13: error: invalid operand for instruction
+yss x1, c2, ddc

--- a/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-invalid.s
+++ b/llvm/test/MC/RISCV/cheri/rvy-mnemonic-compat-invalid.s
@@ -14,15 +14,15 @@ yss x1, ddc, x3
 yss x1, x2, ddc
 
 ## Check that in integer mode jumps reject capability registers.
-# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Mode
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Pointer Mode
 jr c1
-# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Mode
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Pointer Mode
 jalr c1, c2
-# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Mode
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Pointer Mode
 jal c1, 20
 
 ## Normal loads should reject C base registers.
-# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Mode
+# CHECK-INT: :[[@LINE+1]]:1: error: instruction requires the following: Capability Pointer Mode
 lw x1, 0(c2)
 
 ## Check that XCheri mnemonics do not coerce arguments.

--- a/llvm/test/MC/RISCV/cheri/rvyc-mnemonic-compat-capmode.s
+++ b/llvm/test/MC/RISCV/cheri/rvyc-mnemonic-compat-capmode.s
@@ -1,0 +1,48 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+c,+xcheri,+cap-mode,+f,+d -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck --check-prefixes=CHECK,CHECK-32 %s
+# RUN: llvm-mc %s --defsym RV64=1 -triple=riscv64 -mattr=+c,+xcheri,+cap-mode,+f,+d -riscv-no-aliases -show-encoding \
+# RUN:     | FileCheck --check-prefixes=CHECK,CHECK-64 %s
+
+## Check that compressed loads/stores accept GPR base registers in CapMode
+# CHECK-32: c.lc ca0, 32(ca1) # encoding: [0x88,0x71]
+# CHECK-64: c.lc ca0, 32(ca1) # encoding: [0x88,0x31]
+c.ly ca0, 32(ca1)
+# CHECK-32: c.sc ca0, 32(ca1) # encoding: [0x88,0xf1]
+# CHECK-64: c.sc ca0, 32(ca1) # encoding: [0x88,0xb1]
+c.sy ca0, 32(ca1)
+# CHECK-32: c.lcsp ca0, 32(csp) # encoding: [0x02,0x75]
+# CHECK-64: c.lcsp ca0, 32(csp) # encoding: [0x02,0x35]
+c.lysp ca0, 32(csp)
+# CHECK-32: c.scsp ca0, 32(csp) # encoding: [0x2a,0xf0]
+# CHECK-64: c.scsp ca0, 32(csp) # encoding: [0x2a,0xb0]
+c.sysp ca0, 32(csp)
+
+## TODO: The normal loads/stores should also accept x registers
+# CHECK: c.lw a2, 8(ca1) # encoding: [0x90,0x45]
+c.lw a2, 8(ca1)
+# CHECK: c.sw a5, 8(ca1) # encoding: [0x9c,0xc5]
+c.sw a5, 8(ca1)
+# CHECK: c.lwsp a0, 8(csp) # encoding: [0x22,0x45]
+c.lwsp a0, 8(csp)
+# CHECK: c.swsp a0, 8(csp) # encoding: [0x2a,0xc4]
+c.swsp a0, 8(csp)
+
+.ifdef RV64
+# CHECK-64: c.ld a0, 16(ca1) # encoding: [0x88,0x69]
+c.ld a0, 16(ca1)
+# CHECK-64: c.sd a0, 16(ca1) # encoding: [0x88,0xe9]
+c.sd a0, 16(ca1)
+# CHECK-64: c.ldsp a0, 16(csp) # encoding: [0x42,0x65]
+c.ldsp a0, 16(csp)
+# CHECK-64: c.sdsp a0, 16(csp) # encoding: [0x2a,0xe8]
+c.sdsp a0, 16(csp)
+.else
+# CHECK-32: c.fld fa5, 8(ca1) # encoding: [0x9c,0x25]
+c.fld fa5, 8(ca1)
+# CHECK-32: c.fsd fa5, 8(ca1) # encoding: [0x9c,0xa5]
+c.fsd fa5, 8(ca1)
+# CHECK-32: c.fldsp fa5, 8(csp) # encoding: [0xa2,0x27]
+c.fldsp fa5, 8(csp)
+# CHECK-32: c.fsdsp fa5, 8(csp) # encoding: [0x3e,0xa4]
+c.fsdsp fa5, 8(csp)
+.endif

--- a/llvm/test/MC/RISCV/cheri/rvyc-mnemonic-compat-capmode.s
+++ b/llvm/test/MC/RISCV/cheri/rvyc-mnemonic-compat-capmode.s
@@ -6,43 +6,48 @@
 ## Check that compressed loads/stores accept GPR base registers in CapMode
 # CHECK-32: c.lc ca0, 32(ca1) # encoding: [0x88,0x71]
 # CHECK-64: c.lc ca0, 32(ca1) # encoding: [0x88,0x31]
-c.ly ca0, 32(ca1)
-# CHECK-32: c.sc ca0, 32(ca1) # encoding: [0x88,0xf1]
-# CHECK-64: c.sc ca0, 32(ca1) # encoding: [0x88,0xb1]
-c.sy ca0, 32(ca1)
-# CHECK-32: c.lcsp ca0, 32(csp) # encoding: [0x02,0x75]
-# CHECK-64: c.lcsp ca0, 32(csp) # encoding: [0x02,0x35]
-c.lysp ca0, 32(csp)
-# CHECK-32: c.scsp ca0, 32(csp) # encoding: [0x2a,0xf0]
-# CHECK-64: c.scsp ca0, 32(csp) # encoding: [0x2a,0xb0]
-c.sysp ca0, 32(csp)
-
-## TODO: The normal loads/stores should also accept x registers
+c.ly a0, 32(a1)
+# CHECK-32-NEXT: c.sc ca0, 32(ca1) # encoding: [0x88,0xf1]
+# CHECK-64-NEXT: c.sc ca0, 32(ca1) # encoding: [0x88,0xb1]
+c.sy a0, 32(a1)
+# CHECK-32-NEXT: c.lcsp ca0, 32(csp) # encoding: [0x02,0x75]
+# CHECK-64-NEXT: c.lcsp ca0, 32(csp) # encoding: [0x02,0x35]
+c.lysp a0, 32(sp)
+# CHECK-32-NEXT: c.scsp ca0, 32(csp) # encoding: [0x2a,0xf0]
+# CHECK-64-NEXT: c.scsp ca0, 32(csp) # encoding: [0x2a,0xb0]
+c.sysp a0, 32(sp)
+#
+## The normal loads/stores/jumps should also accept x registers
+#
 # CHECK: c.lw a2, 8(ca1) # encoding: [0x90,0x45]
-c.lw a2, 8(ca1)
+c.lw a2, 8(a1)
 # CHECK: c.sw a5, 8(ca1) # encoding: [0x9c,0xc5]
-c.sw a5, 8(ca1)
+c.sw a5, 8(a1)
 # CHECK: c.lwsp a0, 8(csp) # encoding: [0x22,0x45]
-c.lwsp a0, 8(csp)
+c.lwsp a0, 8(sp)
 # CHECK: c.swsp a0, 8(csp) # encoding: [0x2a,0xc4]
-c.swsp a0, 8(csp)
-
+c.swsp a0, 8(sp)
+# CHECK-NEXT: c.jr ca1 # encoding: [0x82,0x85]
+c.jr a1
+# CHECK-NEXT: c.jalr ca1 # encoding: [0x82,0x95]
+c.jalr a1
+#
 .ifdef RV64
-# CHECK-64: c.ld a0, 16(ca1) # encoding: [0x88,0x69]
-c.ld a0, 16(ca1)
-# CHECK-64: c.sd a0, 16(ca1) # encoding: [0x88,0xe9]
-c.sd a0, 16(ca1)
-# CHECK-64: c.ldsp a0, 16(csp) # encoding: [0x42,0x65]
-c.ldsp a0, 16(csp)
-# CHECK-64: c.sdsp a0, 16(csp) # encoding: [0x2a,0xe8]
-c.sdsp a0, 16(csp)
+# CHECK-64-NEXT: c.ld a0, 16(ca1) # encoding: [0x88,0x69]
+c.ld a0, 16(a1)
+# CHECK-64-NEXT: c.sd a0, 16(ca1) # encoding: [0x88,0xe9]
+c.sd a0, 16(a1)
+# CHECK-64-NEXT: c.ldsp a0, 16(csp) # encoding: [0x42,0x65]
+c.ldsp a0, 16(sp)
+# CHECK-64-NEXT: c.sdsp a0, 16(csp) # encoding: [0x2a,0xe8]
+c.sdsp a0, 16(sp)
 .else
-# CHECK-32: c.fld fa5, 8(ca1) # encoding: [0x9c,0x25]
-c.fld fa5, 8(ca1)
-# CHECK-32: c.fsd fa5, 8(ca1) # encoding: [0x9c,0xa5]
-c.fsd fa5, 8(ca1)
-# CHECK-32: c.fldsp fa5, 8(csp) # encoding: [0xa2,0x27]
-c.fldsp fa5, 8(csp)
-# CHECK-32: c.fsdsp fa5, 8(csp) # encoding: [0x3e,0xa4]
-c.fsdsp fa5, 8(csp)
+# CHECK-32-NEXT: c.fld fa5, 8(ca1) # encoding: [0x9c,0x25]
+c.fld fa5, 8(a1)
+# CHECK-32-NEXT: c.fsd fa5, 8(ca1) # encoding: [0x9c,0xa5]
+c.fsd fa5, 8(a1)
+# CHECK-32-NEXT: c.fldsp fa5, 8(csp) # encoding: [0xa2,0x27]
+c.fldsp fa5, 8(sp)
+# CHECK-32-NEXT: c.fsdsp fa5, 8(csp) # encoding: [0x3e,0xa4]
+c.fsdsp fa5, 8(sp)
 .endif

--- a/llvm/test/MC/RISCV/rvi-pseudos-invalid.s
+++ b/llvm/test/MC/RISCV/rvi-pseudos-invalid.s
@@ -12,7 +12,7 @@ lga x1, %hi(foo) # CHECK: :[[@LINE]]:9: error: operand must be a bare symbol nam
 lga x1, %lo(foo) # CHECK: :[[@LINE]]:9: error: operand must be a bare symbol name
 
 sw a2, %hi(a_symbol), a3 # CHECK: :[[@LINE]]:8: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or an integer in the range [-2048, 2047]
-sw a2, %lo(a_symbol), a3 # CHECK: :[[@LINE]]:23: error: operand must be a bare symbol name
+sw a2, %lo(a_symbol), a3 # CHECK: :[[@LINE]]:23: error: invalid operand for instruction
 sw a2, %lo(a_symbol)(a4), a3 # CHECK: :[[@LINE]]:27: error: invalid operand for instruction
 
 # Too few operands must be rejected


### PR DESCRIPTION
This builds on the final version of https://github.com/CTSRD-CHERI/llvm-project/pull/818 and is now much simpler than #25 since we have actual YGPR operand classes.

While doign this I also noticed a zcb CompressPat bug which is now fixed.